### PR TITLE
Fully support multiple primary clients

### DIFF
--- a/output.c
+++ b/output.c
@@ -133,7 +133,7 @@ handle_output_frame(struct wl_listener *listener, void *data)
 		view_for_each_surface(view, render_surface, &rdata);
 		/* If we have dialogs open and this view is not the
 		   top of the stack, draw an overlay. */
-		if (have_dialogs_open(output->server) &&
+		if (view_has_children(output->server, view) &&
 		    view->link.prev != &output->server->views) {
 			render_overlay(renderer, output->wlr_output, width, height);
 		}

--- a/seat.h
+++ b/seat.h
@@ -85,6 +85,5 @@ struct cg_seat *cg_seat_create(struct cg_server *server);
 void cg_seat_destroy(struct cg_seat *seat);
 struct cg_view *seat_get_focus(struct cg_seat *seat);
 void seat_set_focus(struct cg_seat *seat, struct cg_view *view);
-bool have_dialogs_open(struct cg_server *server);
 
 #endif

--- a/view.c
+++ b/view.c
@@ -68,6 +68,18 @@ view_is_primary(struct cg_view *view)
 	return view->is_primary(view);
 }
 
+bool
+view_has_children(struct cg_server *server, struct cg_view *parent)
+{
+	struct cg_view *child;
+	wl_list_for_each(child, &server->views, link) {
+		if (parent != child && parent->is_parent(parent, child)) {
+			return true;
+		}
+	}
+	return false;
+}
+
 void
 view_position(struct cg_view *view)
 {

--- a/view.c
+++ b/view.c
@@ -112,17 +112,17 @@ void
 view_destroy(struct cg_view *view)
 {
 	struct cg_server *server = view->server;
-	bool terminate = view_is_primary(view);
 
 	if (view->wlr_surface != NULL) {
 		view_unmap(view);
 	}
 	free(view);
 
-	/* If this was our primary view, exit. Otherwise, focus the
+	/* If this was our last primary view, exit. Otherwise, focus the
 	   previous (i.e., next highest in the stack) view. Since
 	   we're still here, we know there is at least one view in the
 	   list. */
+	bool terminate = wl_list_empty(&server->views);
 	if (terminate) {
 		wl_display_terminate(server->wl_display);
 	} else {

--- a/view.h
+++ b/view.h
@@ -49,6 +49,7 @@ struct cg_view {
 	struct wlr_surface *(*wlr_surface_at)(struct cg_view *view, double sx, double sy,
 					      double *sub_x, double *sub_y);
 	bool (*is_primary)(struct cg_view *view);
+	bool (*is_parent)(struct cg_view *parent, struct cg_view *child);
 };
 
 void view_activate(struct cg_view *view, bool activate);
@@ -56,6 +57,7 @@ void view_for_each_surface(struct cg_view *view, wlr_surface_iterator_func_t ite
 struct wlr_surface *view_wlr_surface_at(struct cg_view *view, double sx, double sy,
 					double *sub_x, double *sub_y);
 bool view_is_primary(struct cg_view *view);
+bool view_has_children(struct cg_server *server, struct cg_view *view);
 void view_position(struct cg_view *view);
 void view_unmap(struct cg_view *view);
 void view_map(struct cg_view *view, struct wlr_surface *surface);

--- a/xdg_shell.c
+++ b/xdg_shell.c
@@ -58,6 +58,12 @@ is_primary(struct cg_view *view)
 	return parent == NULL; /*&& role == WLR_XDG_SURFACE_ROLE_TOPLEVEL */
 }
 
+static bool
+is_parent(struct cg_view *parent, struct cg_view *child)
+{
+	return child->xdg_surface->toplevel->parent == parent->xdg_surface;
+}
+
 static void
 handle_xdg_shell_surface_unmap(struct wl_listener *listener, void *data)
 {
@@ -106,4 +112,5 @@ handle_xdg_shell_surface_new(struct wl_listener *listener, void *data)
 	view->for_each_surface = for_each_surface;
 	view->wlr_surface_at = wlr_surface_at;
 	view->is_primary = is_primary;
+	view->is_parent = is_parent;
 }

--- a/xwayland.c
+++ b/xwayland.c
@@ -54,6 +54,12 @@ is_primary(struct cg_view *view)
 	return parent == NULL;
 }
 
+static bool
+is_parent(struct cg_view *parent, struct cg_view *child)
+{
+	return child->xwayland_surface->parent == parent->xwayland_surface;
+}
+
 static void
 handle_xwayland_surface_unmap(struct wl_listener *listener, void *data)
 {
@@ -98,4 +104,5 @@ handle_xwayland_surface_new(struct wl_listener *listener, void *data)
 	view->for_each_surface = for_each_surface;
 	view->wlr_surface_at = wlr_surface_at;
 	view->is_primary = is_primary;
+	view->is_parent = is_parent;
 }


### PR DESCRIPTION
This is the path we settled on in #24.

That is: any new toplevel window takes over the Cage display, hiding any previous toplevels until it is closed. Only when the last toplevel is closed, does Cage exit as well.