### PR TITLE
Abstract views

### DIFF
--- a/cage.c
+++ b/cage.c
@@ -170,7 +170,7 @@ main(int argc, char *argv[])
 	server.new_output.notify = handle_new_output;
 	wl_signal_add(&server.backend->events.new_output, &server.new_output);
 
-	server.seat = cg_seat_create(&server);
+	server.seat = seat_create(&server);
 	if (!server.seat) {
 		wlr_log(WLR_ERROR, "Unable to create the seat");
 		ret = 1;

--- a/output.c
+++ b/output.c
@@ -27,15 +27,6 @@
 #include "server.h"
 #include "view.h"
 
-static void
-render_overlay(struct wlr_renderer *renderer, struct wlr_output *output, int width, int height)
-{
-	struct wlr_box box = { .width = width, .height = height };
-	float color[4] = { 0.0, 0.0, 0.0, 0.3 };
-
-	wlr_render_rect(renderer, &box, color, output->transform_matrix);
-}
-
 /* Used to move all of the data necessary to render a surface from the
  * top-level frame handler to the per-surface render function. */
 struct render_data {
@@ -131,15 +122,6 @@ handle_output_frame(struct wl_listener *listener, void *data)
 		rdata.x = view->x;
 		rdata.y = view->y;
 		view_for_each_surface(view, render_surface, &rdata);
-		/* If this view is on top of the stack and has
-		   children, draw an overlay over it. */
-		// TODO: replace this hacky mess with a transient_for
-		// pointer in cg_view or something and then draw an
-		// overlay over this cg_view only.
-		if (&view->link == output->server->views.prev &&
-		    view_has_children(output->server, view)) {
-			render_overlay(renderer, output->wlr_output, width, height);
-		}
 	}
 
 	drag_icons_for_each_surface(output->server, render_surface, &rdata);

--- a/seat.c
+++ b/seat.c
@@ -614,7 +614,7 @@ handle_destroy(struct wl_listener *listener, void *data)
 }
 
 struct cg_seat *
-cg_seat_create(struct cg_server *server)
+seat_create(struct cg_server *server)
 {
 	struct cg_seat *seat = calloc(1, sizeof(struct cg_seat));
 	if (!seat) {

--- a/seat.c
+++ b/seat.c
@@ -692,7 +692,7 @@ struct cg_view *
 seat_get_focus(struct cg_seat *seat)
 {
 	struct wlr_surface *prev_surface = seat->seat->keyboard_state.focused_surface;
-	return cg_view_from_wlr_surface(seat->server, prev_surface);
+	return view_from_wlr_surface(seat->server, prev_surface);
 }
 
 void

--- a/seat.c
+++ b/seat.c
@@ -89,9 +89,14 @@ press_cursor_button(struct cg_seat *seat, struct wlr_input_device *device,
 		struct wlr_surface *surface;
 		struct cg_view *view = desktop_view_at(server, lx, ly,
 						       &surface, &sx, &sy);
+		struct cg_view *current = seat_get_focus(seat);
+		if (view == current) {
+			return;
+		}
+
 		/* Focus that client if the button was pressed and
 		   it has no open dialogs. */
-		if (view && !view_has_children(server, view)) {
+		if (view && !view_is_transient_for(current, view)) {
 			seat_set_focus(seat, view);
 		}
 	}

--- a/seat.c
+++ b/seat.c
@@ -27,6 +27,9 @@
 #include "seat.h"
 #include "server.h"
 #include "view.h"
+#if CAGE_HAS_XWAYLAND
+#include "xwayland.h"
+#endif
 
 static void drag_icon_update_position(struct cg_drag_icon *drag_icon);
 
@@ -707,9 +710,11 @@ seat_set_focus(struct cg_seat *seat, struct cg_view *view)
 	}
 
 #if CAGE_HAS_XWAYLAND
-	if (view->type == CAGE_XWAYLAND_VIEW &&
-	    !wlr_xwayland_or_surface_wants_focus(view->xwayland_surface)) {
-		return;
+	if (view->type == CAGE_XWAYLAND_VIEW) {
+		struct cg_xwayland_view *xwayland_view = xwayland_view_from_view(view);
+		if (!wlr_xwayland_or_surface_wants_focus(xwayland_view->xwayland_surface)) {
+			return;
+		}
 	}
 #endif
 

--- a/seat.h
+++ b/seat.h
@@ -80,7 +80,7 @@ struct cg_drag_icon {
 	struct wl_listener destroy;
 };
 
-struct cg_seat *cg_seat_create(struct cg_server *server);
+struct cg_seat *seat_create(struct cg_server *server);
 void cg_seat_destroy(struct cg_seat *seat);
 struct cg_view *seat_get_focus(struct cg_seat *seat);
 void seat_set_focus(struct cg_seat *seat, struct cg_view *view);

--- a/view.c
+++ b/view.c
@@ -20,6 +20,9 @@
 #include "seat.h"
 #include "server.h"
 #include "view.h"
+#if CAGE_HAS_XWAYLAND
+#include "xwayland.h"
+#endif
 
 char *
 view_get_title(struct cg_view *view)
@@ -115,6 +118,14 @@ void
 view_destroy(struct cg_view *view)
 {
 	struct cg_server *server = view->server;
+	bool ever_been_mapped = true;
+
+#if CAGE_HAS_XWAYLAND
+	if (view->type == CAGE_XWAYLAND_VIEW) {
+		struct cg_xwayland_view *xwayland_view = xwayland_view_from_view(view);
+		ever_been_mapped = xwayland_view->ever_been_mapped;
+	}
+#endif
 
 	if (view->wlr_surface != NULL) {
 		view_unmap(view);
@@ -127,7 +138,7 @@ view_destroy(struct cg_view *view)
 	if (!empty) {
 		struct cg_view *prev = wl_container_of(server->views.next, prev, link);
 		seat_set_focus(server->seat, prev);
-	} else {
+	} else if (ever_been_mapped) {
 		/* The list is empty and the last view has been
 		   mapped, so we can safely exit. */
 		wl_display_terminate(server->wl_display);

--- a/view.c
+++ b/view.c
@@ -24,14 +24,14 @@
 char *
 view_get_title(struct cg_view *view)
 {
-	const char *title = view->get_title(view);
+	const char *title = view->impl->get_title(view);
 	return strndup(title, strlen(title));
 }
 
 void
 view_activate(struct cg_view *view, bool activate)
 {
-	view->activate(view, activate);
+	view->impl->activate(view, activate);
 }
 
 static void
@@ -41,7 +41,7 @@ view_maximize(struct cg_view *view)
 	int output_width, output_height;
 
 	wlr_output_transformed_resolution(output->wlr_output, &output_width, &output_height);
-	view->maximize(view, output_width, output_height);
+	view->impl->maximize(view, output_width, output_height);
 }
 
 static void
@@ -53,29 +53,28 @@ view_center(struct cg_view *view)
 	wlr_output_transformed_resolution(output, &output_width, &output_height);
 
 	int width, height;
-	view->get_geometry(view, &width, &height);
+	view->impl->get_geometry(view, &width, &height);
 
 	view->x = (output_width - width) / 2;
 	view->y = (output_height - height) / 2;
 }
 
 void
-view_for_each_surface(struct cg_view *view, wlr_surface_iterator_func_t iterator,
-		      void *data)
+view_for_each_surface(struct cg_view *view, wlr_surface_iterator_func_t iterator, void *data)
 {
-	view->for_each_surface(view, iterator, data);
+	view->impl->for_each_surface(view, iterator, data);
 }
 
 struct wlr_surface *
 view_wlr_surface_at(struct cg_view *view, double sx, double sy, double *sub_x, double *sub_y)
 {
-	return view->wlr_surface_at(view, sx, sy, sub_x, sub_y);
+	return view->impl->wlr_surface_at(view, sx, sy, sub_x, sub_y);
 }
 
 bool
 view_is_primary(struct cg_view *view)
 {
-	return view->is_primary(view);
+	return view->impl->is_primary(view);
 }
 
 bool
@@ -83,7 +82,7 @@ view_has_children(struct cg_server *server, struct cg_view *parent)
 {
 	struct cg_view *child;
 	wl_list_for_each(child, &server->views, link) {
-		if (parent != child && parent->is_parent(parent, child)) {
+		if (parent != child && parent->impl->is_parent(parent, child)) {
 			return true;
 		}
 	}
@@ -122,50 +121,32 @@ void
 view_destroy(struct cg_view *view)
 {
 	struct cg_server *server = view->server;
-	bool mapped = true;
-
-#if CAGE_HAS_XWAYLAND
-	/* Some applications that aren't yet Wayland-native or
-	   otherwise "special" (e.g. Firefox Nightly and Google
-	   Chrome/Chromium) spawn an XWayland surface upon startup
-	   that is almost immediately closed again. This makes Cage
-	   think there are no views left, which results in it
-	   exiting. However, after this initial (unmapped) surface,
-	   the "real" application surface is opened. This leads to
-	   these applications' startup sequences being interrupted by
-	   Cage exiting. Hence, to work around this issue, Cage checks
-	   whether an XWayland surface has been mapped and exits only
-	   if 1) the XWayland surface has been mapped and 2) this was
-	   the last surface Cage manages. */
-	if (view->type == CAGE_XWAYLAND_VIEW) {
-		mapped = view->xwayland_surface->mapped;
-	}
-#endif
 
 	if (view->wlr_surface != NULL) {
 		view_unmap(view);
 	}
-	free(view);
+
+	view->impl->destroy(view);
 
 	/* If there is a previous view in the list, focus that. */
 	bool empty = wl_list_empty(&server->views);
 	if (!empty) {
 		struct cg_view *prev = wl_container_of(server->views.next, prev, link);
 		seat_set_focus(server->seat, prev);
-	} else if (mapped) {
+	} else {
 		/* The list is empty and the last view has been
 		   mapped, so we can safely exit. */
 		wl_display_terminate(server->wl_display);
 	}
 }
 
-struct cg_view *
-view_create(struct cg_server *server)
+void
+view_init(struct cg_view *view, struct cg_server *server, enum cg_view_type type,
+	  const struct cg_view_impl *impl)
 {
-	struct cg_view *view = calloc(1, sizeof(struct cg_view));
-
 	view->server = server;
-	return view;
+	view->type = type;
+	view->impl = impl;
 }
 
 struct cg_view *

--- a/view.c
+++ b/view.c
@@ -38,15 +38,8 @@ view_is_primary(struct cg_view *view)
 }
 
 bool
-view_has_children(struct cg_server *server, struct cg_view *parent)
-{
-	struct cg_view *child;
-	wl_list_for_each(child, &server->views, link) {
-		if (parent != child && parent->impl->is_parent(parent, child)) {
-			return true;
-		}
-	}
-	return false;
+view_is_transient_for(struct cg_view *child, struct cg_view *parent) {
+	return child->impl->is_transient_for(child, parent);
 }
 
 void

--- a/view.c
+++ b/view.c
@@ -160,7 +160,7 @@ view_destroy(struct cg_view *view)
 }
 
 struct cg_view *
-cg_view_create(struct cg_server *server)
+view_create(struct cg_server *server)
 {
 	struct cg_view *view = calloc(1, sizeof(struct cg_view));
 
@@ -169,7 +169,7 @@ cg_view_create(struct cg_server *server)
 }
 
 struct cg_view *
-cg_view_from_wlr_surface(struct cg_server *server, struct wlr_surface *surface)
+view_from_wlr_surface(struct cg_server *server, struct wlr_surface *surface)
 {
 	struct cg_view *view;
 	wl_list_for_each(view, &server->views, link) {

--- a/view.c
+++ b/view.c
@@ -28,6 +28,24 @@ view_get_title(struct cg_view *view)
 	return strndup(title, strlen(title));
 }
 
+bool
+view_is_primary(struct cg_view *view)
+{
+	return view->impl->is_primary(view);
+}
+
+bool
+view_has_children(struct cg_server *server, struct cg_view *parent)
+{
+	struct cg_view *child;
+	wl_list_for_each(child, &server->views, link) {
+		if (parent != child && parent->impl->is_parent(parent, child)) {
+			return true;
+		}
+	}
+	return false;
+}
+
 void
 view_activate(struct cg_view *view, bool activate)
 {
@@ -60,36 +78,6 @@ view_center(struct cg_view *view)
 }
 
 void
-view_for_each_surface(struct cg_view *view, wlr_surface_iterator_func_t iterator, void *data)
-{
-	view->impl->for_each_surface(view, iterator, data);
-}
-
-struct wlr_surface *
-view_wlr_surface_at(struct cg_view *view, double sx, double sy, double *sub_x, double *sub_y)
-{
-	return view->impl->wlr_surface_at(view, sx, sy, sub_x, sub_y);
-}
-
-bool
-view_is_primary(struct cg_view *view)
-{
-	return view->impl->is_primary(view);
-}
-
-bool
-view_has_children(struct cg_server *server, struct cg_view *parent)
-{
-	struct cg_view *child;
-	wl_list_for_each(child, &server->views, link) {
-		if (parent != child && parent->impl->is_parent(parent, child)) {
-			return true;
-		}
-	}
-	return false;
-}
-
-void
 view_position(struct cg_view *view)
 {
 	if (view_is_primary(view)) {
@@ -97,6 +85,12 @@ view_position(struct cg_view *view)
 	} else {
 		view_center(view);
 	}
+}
+
+void
+view_for_each_surface(struct cg_view *view, wlr_surface_iterator_func_t iterator, void *data)
+{
+	view->impl->for_each_surface(view, iterator, data);
 }
 
 void
@@ -159,4 +153,10 @@ view_from_wlr_surface(struct cg_server *server, struct wlr_surface *surface)
 		}
 	}
 	return NULL;
+}
+
+struct wlr_surface *
+view_wlr_surface_at(struct cg_view *view, double sx, double sy, double *sub_x, double *sub_y)
+{
+	return view->impl->wlr_surface_at(view, sx, sy, sub_x, sub_y);
 }

--- a/view.h
+++ b/view.h
@@ -35,7 +35,7 @@ struct cg_view_impl {
 	char *(*get_title)(struct cg_view *view);
 	void (*get_geometry)(struct cg_view *view, int *width_out, int *height_out);
 	bool (*is_primary)(struct cg_view *view);
-	bool (*is_parent)(struct cg_view *parent, struct cg_view *child);
+	bool (*is_transient_for)(struct cg_view *child, struct cg_view *parent);
 	void (*activate)(struct cg_view *view, bool activate);
 	void (*maximize)(struct cg_view *view, int output_width, int output_height);
 	void (*destroy)(struct cg_view *view);
@@ -47,7 +47,7 @@ struct cg_view_impl {
 
 char *view_get_title(struct cg_view *view);
 bool view_is_primary(struct cg_view *view);
-bool view_has_children(struct cg_server *server, struct cg_view *view);
+bool view_is_transient_for(struct cg_view *child, struct cg_view *parent);
 void view_activate(struct cg_view *view, bool activate);
 void view_position(struct cg_view *view);
 void view_for_each_surface(struct cg_view *view, wlr_surface_iterator_func_t iterator, void *data);

--- a/view.h
+++ b/view.h
@@ -33,26 +33,24 @@ struct cg_view {
 
 struct cg_view_impl {
 	char *(*get_title)(struct cg_view *view);
+	void (*get_geometry)(struct cg_view *view, int *width_out, int *height_out);
+	bool (*is_primary)(struct cg_view *view);
+	bool (*is_parent)(struct cg_view *parent, struct cg_view *child);
 	void (*activate)(struct cg_view *view, bool activate);
 	void (*maximize)(struct cg_view *view, int output_width, int output_height);
-	void (*get_geometry)(struct cg_view *view, int *width_out, int *height_out);
 	void (*destroy)(struct cg_view *view);
 	void (*for_each_surface)(struct cg_view *view, wlr_surface_iterator_func_t iterator,
 				 void *data);
 	struct wlr_surface *(*wlr_surface_at)(struct cg_view *view, double sx, double sy,
 					      double *sub_x, double *sub_y);
-	bool (*is_primary)(struct cg_view *view);
-	bool (*is_parent)(struct cg_view *parent, struct cg_view *child);
 };
 
 char *view_get_title(struct cg_view *view);
-void view_activate(struct cg_view *view, bool activate);
-void view_for_each_surface(struct cg_view *view, wlr_surface_iterator_func_t iterator, void *data);
-struct wlr_surface *view_wlr_surface_at(struct cg_view *view, double sx, double sy,
-					double *sub_x, double *sub_y);
 bool view_is_primary(struct cg_view *view);
 bool view_has_children(struct cg_server *server, struct cg_view *view);
+void view_activate(struct cg_view *view, bool activate);
 void view_position(struct cg_view *view);
+void view_for_each_surface(struct cg_view *view, wlr_surface_iterator_func_t iterator, void *data);
 void view_unmap(struct cg_view *view);
 void view_map(struct cg_view *view, struct wlr_surface *surface);
 void view_destroy(struct cg_view *view);
@@ -60,5 +58,7 @@ void view_init(struct cg_view *view, struct cg_server *server, enum cg_view_type
 	       const struct cg_view_impl *impl);
 
 struct cg_view *view_from_wlr_surface(struct cg_server *server, struct wlr_surface *surface);
+struct wlr_surface *view_wlr_surface_at(struct cg_view *view, double sx, double sy,
+					double *sub_x, double *sub_y);
 
 #endif

--- a/view.h
+++ b/view.h
@@ -64,7 +64,8 @@ void view_position(struct cg_view *view);
 void view_unmap(struct cg_view *view);
 void view_map(struct cg_view *view, struct wlr_surface *surface);
 void view_destroy(struct cg_view *view);
-struct cg_view *cg_view_create(struct cg_server *server);
-struct cg_view *cg_view_from_wlr_surface(struct cg_server *server, struct wlr_surface *surface);
+struct cg_view *view_create(struct cg_server *server);
+
+struct cg_view *view_from_wlr_surface(struct cg_server *server, struct wlr_surface *surface);
 
 #endif

--- a/view.h
+++ b/view.h
@@ -28,23 +28,15 @@ struct cg_view {
 	int x, y;
 
 	enum cg_view_type type;
-	union {
-		struct wlr_xdg_surface *xdg_surface;
-#if CAGE_HAS_XWAYLAND
-		struct wlr_xwayland_surface *xwayland_surface;
-#endif
-	};
+	const struct cg_view_impl *impl;
+};
 
-	struct wl_listener destroy;
-	struct wl_listener unmap;
-	struct wl_listener map;
-	// TODO: allow applications to go to fullscreen from maximized?
-	// struct wl_listener request_fullscreen;
-
+struct cg_view_impl {
 	char *(*get_title)(struct cg_view *view);
 	void (*activate)(struct cg_view *view, bool activate);
 	void (*maximize)(struct cg_view *view, int output_width, int output_height);
 	void (*get_geometry)(struct cg_view *view, int *width_out, int *height_out);
+	void (*destroy)(struct cg_view *view);
 	void (*for_each_surface)(struct cg_view *view, wlr_surface_iterator_func_t iterator,
 				 void *data);
 	struct wlr_surface *(*wlr_surface_at)(struct cg_view *view, double sx, double sy,
@@ -64,7 +56,8 @@ void view_position(struct cg_view *view);
 void view_unmap(struct cg_view *view);
 void view_map(struct cg_view *view, struct wlr_surface *surface);
 void view_destroy(struct cg_view *view);
-struct cg_view *view_create(struct cg_server *server);
+void view_init(struct cg_view *view, struct cg_server *server, enum cg_view_type type,
+	       const struct cg_view_impl *impl);
 
 struct cg_view *view_from_wlr_surface(struct cg_server *server, struct wlr_surface *surface);
 

--- a/xdg_shell.c
+++ b/xdg_shell.c
@@ -31,6 +31,37 @@ get_title(struct cg_view *view)
 }
 
 static void
+get_geometry(struct cg_view *view, int *width_out, int *height_out)
+{
+	struct cg_xdg_shell_view *xdg_shell_view = xdg_shell_view_from_view(view);
+	struct wlr_box geom;
+
+	wlr_xdg_surface_get_geometry(xdg_shell_view->xdg_surface, &geom);
+	*width_out = geom.width;
+	*height_out = geom.height;
+}
+
+static bool
+is_primary(struct cg_view *view)
+{
+	struct cg_xdg_shell_view *xdg_shell_view = xdg_shell_view_from_view(view);
+	struct wlr_xdg_surface *parent = xdg_shell_view->xdg_surface->toplevel->parent;
+	/* FIXME: role is 0? */
+	return parent == NULL; /*&& role == WLR_XDG_SURFACE_ROLE_TOPLEVEL */
+}
+
+static bool
+is_parent(struct cg_view *parent, struct cg_view *child)
+{
+	if (child->type != CAGE_XDG_SHELL_VIEW) {
+		return false;
+	}
+	struct cg_xdg_shell_view *_parent = xdg_shell_view_from_view(parent);
+	struct cg_xdg_shell_view *_child = xdg_shell_view_from_view(child);
+	return _child->xdg_surface->toplevel->parent == _parent->xdg_surface;
+}
+
+static void
 activate(struct cg_view *view, bool activate)
 {
 	struct cg_xdg_shell_view *xdg_shell_view = xdg_shell_view_from_view(view);
@@ -53,17 +84,6 @@ destroy(struct cg_view *view)
 }
 
 static void
-get_geometry(struct cg_view *view, int *width_out, int *height_out)
-{
-	struct cg_xdg_shell_view *xdg_shell_view = xdg_shell_view_from_view(view);
-	struct wlr_box geom;
-
-	wlr_xdg_surface_get_geometry(xdg_shell_view->xdg_surface, &geom);
-	*width_out = geom.width;
-	*height_out = geom.height;
-}
-
-static void
 for_each_surface(struct cg_view *view, wlr_surface_iterator_func_t iterator, void *data)
 {
 	struct cg_xdg_shell_view *xdg_shell_view = xdg_shell_view_from_view(view);
@@ -75,26 +95,6 @@ wlr_surface_at(struct cg_view *view, double sx, double sy, double *sub_x, double
 {
 	struct cg_xdg_shell_view *xdg_shell_view = xdg_shell_view_from_view(view);
 	return wlr_xdg_surface_surface_at(xdg_shell_view->xdg_surface, sx, sy, sub_x, sub_y);
-}
-
-static bool
-is_primary(struct cg_view *view)
-{
-	struct cg_xdg_shell_view *xdg_shell_view = xdg_shell_view_from_view(view);
-	struct wlr_xdg_surface *parent = xdg_shell_view->xdg_surface->toplevel->parent;
-	/* FIXME: role is 0? */
-	return parent == NULL; /*&& role == WLR_XDG_SURFACE_ROLE_TOPLEVEL */
-}
-
-static bool
-is_parent(struct cg_view *parent, struct cg_view *child)
-{
-	if (child->type != CAGE_XDG_SHELL_VIEW) {
-		return false;
-	}
-	struct cg_xdg_shell_view *_parent = xdg_shell_view_from_view(parent);
-	struct cg_xdg_shell_view *_child = xdg_shell_view_from_view(child);
-	return _child->xdg_surface->toplevel->parent == _parent->xdg_surface;
 }
 
 static void

--- a/xdg_shell.c
+++ b/xdg_shell.c
@@ -110,7 +110,7 @@ handle_xdg_shell_surface_new(struct wl_listener *listener, void *data)
 		return;
 	}
 
-	struct cg_view *view = cg_view_create(server);
+	struct cg_view *view = view_create(server);
 	view->type = CAGE_XDG_SHELL_VIEW;
 	view->xdg_surface = xdg_surface;
 

--- a/xdg_shell.h
+++ b/xdg_shell.h
@@ -2,6 +2,20 @@
 #define CG_XDG_SHELL_H
 
 #include <wayland-server.h>
+#include <wlr/types/wlr_xdg_shell.h>
+
+#include "view.h"
+
+struct cg_xdg_shell_view {
+	struct cg_view view;
+	struct wlr_xdg_surface *xdg_surface;
+
+	struct wl_listener destroy;
+	struct wl_listener unmap;
+	struct wl_listener map;
+	// TODO: allow applications to go to fullscreen from maximized?
+	// struct wl_listener request_fullscreen;
+};
 
 void handle_xdg_shell_surface_new(struct wl_listener *listener, void *data);
 

--- a/xwayland.c
+++ b/xwayland.c
@@ -102,7 +102,7 @@ handle_xwayland_surface_new(struct wl_listener *listener, void *data)
 	struct cg_server *server = wl_container_of(listener, server, new_xwayland_surface);
 	struct wlr_xwayland_surface *xwayland_surface = data;
 
-	struct cg_view *view = cg_view_create(server);
+	struct cg_view *view = view_create(server);
 	view->type = CAGE_XWAYLAND_VIEW;
 	view->xwayland_surface = xwayland_surface;
 

--- a/xwayland.c
+++ b/xwayland.c
@@ -7,43 +7,61 @@
  */
 
 #include <stdbool.h>
+#include <stdlib.h>
 #include <wayland-server.h>
 #include <wlr/types/wlr_box.h>
 #include <wlr/xwayland.h>
+#include <wlr/util/log.h>
 
 #include "server.h"
 #include "view.h"
 #include "xwayland.h"
 
+struct cg_xwayland_view *
+xwayland_view_from_view(struct cg_view *view)
+{
+	return (struct cg_xwayland_view *) view;
+}
+
 static char *
 get_title(struct cg_view *view)
 {
-	return view->xwayland_surface->title;
+	struct cg_xwayland_view *xwayland_view = xwayland_view_from_view(view);
+	return xwayland_view->xwayland_surface->title;
 }
 
 static void
 activate(struct cg_view *view, bool activate)
 {
-	wlr_xwayland_surface_activate(view->xwayland_surface, activate);
+	struct cg_xwayland_view *xwayland_view = xwayland_view_from_view(view);
+	wlr_xwayland_surface_activate(xwayland_view->xwayland_surface, activate);
 }
 
 static void
 maximize(struct cg_view *view, int output_width, int output_height)
 {
-	wlr_xwayland_surface_configure(view->xwayland_surface, 0, 0, output_width, output_height);
-	wlr_xwayland_surface_set_maximized(view->xwayland_surface, true);
+	struct cg_xwayland_view *xwayland_view = xwayland_view_from_view(view);
+	wlr_xwayland_surface_configure(xwayland_view->xwayland_surface, 0, 0, output_width, output_height);
+	wlr_xwayland_surface_set_maximized(xwayland_view->xwayland_surface, true);
+}
+
+static void
+destroy(struct cg_view *view)
+{
+	struct cg_xwayland_view *xwayland_view = xwayland_view_from_view(view);
+	free(xwayland_view);
 }
 
 static void
 get_geometry(struct cg_view *view, int *width_out, int *height_out)
 {
-	*width_out = view->xwayland_surface->surface->current.width;
-	*height_out = view->xwayland_surface->surface->current.height;
+	struct cg_xwayland_view *xwayland_view = xwayland_view_from_view(view);
+	*width_out = xwayland_view->xwayland_surface->surface->current.width;
+	*height_out = xwayland_view->xwayland_surface->surface->current.height;
 }
 
 static void
-for_each_surface(struct cg_view *view, wlr_surface_iterator_func_t iterator,
-		 void *data)
+for_each_surface(struct cg_view *view, wlr_surface_iterator_func_t iterator, void *data)
 {
 	wlr_surface_for_each_surface(view->wlr_surface, iterator, data);
 }
@@ -57,7 +75,8 @@ wlr_surface_at(struct cg_view *view, double sx, double sy, double *sub_x, double
 static bool
 is_primary(struct cg_view *view)
 {
-	struct wlr_xwayland_surface *parent = view->xwayland_surface->parent;
+	struct cg_xwayland_view *xwayland_view = xwayland_view_from_view(view);
+	struct wlr_xwayland_surface *parent = xwayland_view->xwayland_surface->parent;
 	return parent == NULL;
 }
 
@@ -67,34 +86,54 @@ is_parent(struct cg_view *parent, struct cg_view *child)
 	if (child->type != CAGE_XWAYLAND_VIEW) {
 		return false;
 	}
-	return child->xwayland_surface->parent == parent->xwayland_surface;
+	struct cg_xwayland_view *_parent = xwayland_view_from_view(parent);
+	struct cg_xwayland_view *_child = xwayland_view_from_view(child);
+	return _child->xwayland_surface->parent == _parent->xwayland_surface;
 }
 
 static void
 handle_xwayland_surface_unmap(struct wl_listener *listener, void *data)
 {
-	struct cg_view *view = wl_container_of(listener, view, unmap);
+	struct cg_xwayland_view *xwayland_view = wl_container_of(listener, xwayland_view, unmap);
+	struct cg_view *view = &xwayland_view->view;
+
 	view_unmap(view);
 }
 
 static void
 handle_xwayland_surface_map(struct wl_listener *listener, void *data)
 {
-	struct cg_view *view = wl_container_of(listener, view, map);
-	view_map(view, view->xwayland_surface->surface);
+	struct cg_xwayland_view *xwayland_view = wl_container_of(listener, xwayland_view, map);
+	struct cg_view *view = &xwayland_view->view;
+
+	view_map(view, xwayland_view->xwayland_surface->surface);
 }
 
 static void
 handle_xwayland_surface_destroy(struct wl_listener *listener, void *data)
 {
-	struct cg_view *view = wl_container_of(listener, view, destroy);
+	struct cg_xwayland_view *xwayland_view = wl_container_of(listener, xwayland_view, destroy);
+	struct cg_view *view = &xwayland_view->view;
 
-	wl_list_remove(&view->map.link);
-	wl_list_remove(&view->unmap.link);
-	wl_list_remove(&view->destroy.link);
+	wl_list_remove(&xwayland_view->map.link);
+	wl_list_remove(&xwayland_view->unmap.link);
+	wl_list_remove(&xwayland_view->destroy.link);
+	xwayland_view->xwayland_surface = NULL;
 
 	view_destroy(view);
 }
+
+static const struct cg_view_impl xwayland_view_impl = {
+	.get_title = get_title,
+	.get_geometry = get_geometry,
+	.is_primary = is_primary,
+	.is_parent = is_parent,
+	.activate = activate,
+	.maximize = maximize,
+	.destroy = destroy,
+	.for_each_surface = for_each_surface,
+	.wlr_surface_at = wlr_surface_at,
+};
 
 void
 handle_xwayland_surface_new(struct wl_listener *listener, void *data)
@@ -102,23 +141,19 @@ handle_xwayland_surface_new(struct wl_listener *listener, void *data)
 	struct cg_server *server = wl_container_of(listener, server, new_xwayland_surface);
 	struct wlr_xwayland_surface *xwayland_surface = data;
 
-	struct cg_view *view = view_create(server);
-	view->type = CAGE_XWAYLAND_VIEW;
-	view->xwayland_surface = xwayland_surface;
+	struct cg_xwayland_view *xwayland_view = calloc(1, sizeof(struct cg_xwayland_view));
+	if (!xwayland_view) {
+		wlr_log(WLR_ERROR, "Failed to allocate XWayland view");
+		return;
+	}
 
-	view->map.notify = handle_xwayland_surface_map;
-	wl_signal_add(&xwayland_surface->events.map, &view->map);
-	view->unmap.notify = handle_xwayland_surface_unmap;
-	wl_signal_add(&xwayland_surface->events.unmap, &view->unmap);
-	view->destroy.notify = handle_xwayland_surface_destroy;
-	wl_signal_add(&xwayland_surface->events.destroy, &view->destroy);
+	view_init(&xwayland_view->view, server, CAGE_XWAYLAND_VIEW, &xwayland_view_impl);
+	xwayland_view->xwayland_surface = xwayland_surface;
 
-	view->get_title = get_title;
-	view->activate = activate;
-	view->maximize = maximize;
-	view->get_geometry = get_geometry;
-	view->for_each_surface = for_each_surface;
-	view->wlr_surface_at = wlr_surface_at;
-	view->is_primary = is_primary;
-	view->is_parent = is_parent;
+	xwayland_view->map.notify = handle_xwayland_surface_map;
+	wl_signal_add(&xwayland_surface->events.map, &xwayland_view->map);
+	xwayland_view->unmap.notify = handle_xwayland_surface_unmap;
+	wl_signal_add(&xwayland_surface->events.unmap, &xwayland_view->unmap);
+	xwayland_view->destroy.notify = handle_xwayland_surface_destroy;
+	wl_signal_add(&xwayland_surface->events.destroy, &xwayland_view->destroy);
 }

--- a/xwayland.c
+++ b/xwayland.c
@@ -31,6 +31,33 @@ get_title(struct cg_view *view)
 }
 
 static void
+get_geometry(struct cg_view *view, int *width_out, int *height_out)
+{
+	struct cg_xwayland_view *xwayland_view = xwayland_view_from_view(view);
+	*width_out = xwayland_view->xwayland_surface->surface->current.width;
+	*height_out = xwayland_view->xwayland_surface->surface->current.height;
+}
+
+static bool
+is_primary(struct cg_view *view)
+{
+	struct cg_xwayland_view *xwayland_view = xwayland_view_from_view(view);
+	struct wlr_xwayland_surface *parent = xwayland_view->xwayland_surface->parent;
+	return parent == NULL;
+}
+
+static bool
+is_parent(struct cg_view *parent, struct cg_view *child)
+{
+	if (child->type != CAGE_XWAYLAND_VIEW) {
+		return false;
+	}
+	struct cg_xwayland_view *_parent = xwayland_view_from_view(parent);
+	struct cg_xwayland_view *_child = xwayland_view_from_view(child);
+	return _child->xwayland_surface->parent == _parent->xwayland_surface;
+}
+
+static void
 activate(struct cg_view *view, bool activate)
 {
 	struct cg_xwayland_view *xwayland_view = xwayland_view_from_view(view);
@@ -53,14 +80,6 @@ destroy(struct cg_view *view)
 }
 
 static void
-get_geometry(struct cg_view *view, int *width_out, int *height_out)
-{
-	struct cg_xwayland_view *xwayland_view = xwayland_view_from_view(view);
-	*width_out = xwayland_view->xwayland_surface->surface->current.width;
-	*height_out = xwayland_view->xwayland_surface->surface->current.height;
-}
-
-static void
 for_each_surface(struct cg_view *view, wlr_surface_iterator_func_t iterator, void *data)
 {
 	wlr_surface_for_each_surface(view->wlr_surface, iterator, data);
@@ -70,25 +89,6 @@ static struct wlr_surface *
 wlr_surface_at(struct cg_view *view, double sx, double sy, double *sub_x, double *sub_y)
 {
 	return wlr_surface_surface_at(view->wlr_surface, sx, sy, sub_x, sub_y);
-}
-
-static bool
-is_primary(struct cg_view *view)
-{
-	struct cg_xwayland_view *xwayland_view = xwayland_view_from_view(view);
-	struct wlr_xwayland_surface *parent = xwayland_view->xwayland_surface->parent;
-	return parent == NULL;
-}
-
-static bool
-is_parent(struct cg_view *parent, struct cg_view *child)
-{
-	if (child->type != CAGE_XWAYLAND_VIEW) {
-		return false;
-	}
-	struct cg_xwayland_view *_parent = xwayland_view_from_view(parent);
-	struct cg_xwayland_view *_child = xwayland_view_from_view(child);
-	return _child->xwayland_surface->parent == _parent->xwayland_surface;
 }
 
 static void

--- a/xwayland.c
+++ b/xwayland.c
@@ -106,6 +106,7 @@ handle_xwayland_surface_map(struct wl_listener *listener, void *data)
 	struct cg_xwayland_view *xwayland_view = wl_container_of(listener, xwayland_view, map);
 	struct cg_view *view = &xwayland_view->view;
 
+	xwayland_view->ever_been_mapped = true;
 	view_map(view, xwayland_view->xwayland_surface->surface);
 }
 

--- a/xwayland.h
+++ b/xwayland.h
@@ -2,7 +2,22 @@
 #define CG_XWAYLAND_H
 
 #include <wayland-server.h>
+#include <wlr/xwayland.h>
 
+#include "view.h"
+
+struct cg_xwayland_view {
+	struct cg_view view;
+	struct wlr_xwayland_surface *xwayland_surface;
+
+	struct wl_listener destroy;
+	struct wl_listener unmap;
+	struct wl_listener map;
+	// TODO: allow applications to go to fullscreen from maximized?
+	// struct wl_listener request_fullscreen;
+};
+
+struct cg_xwayland_view *xwayland_view_from_view(struct cg_view *view);
 void handle_xwayland_surface_new(struct wl_listener *listener, void *data);
 
 #endif

--- a/xwayland.h
+++ b/xwayland.h
@@ -10,6 +10,20 @@ struct cg_xwayland_view {
 	struct cg_view view;
 	struct wlr_xwayland_surface *xwayland_surface;
 
+	/* Some applications that aren't yet Wayland-native or
+	   otherwise "special" (e.g. Firefox Nightly and Google
+	   Chrome/Chromium) spawn an XWayland surface upon startup
+	   that is almost immediately closed again. This makes Cage
+	   think there are no views left, which results in it
+	   exiting. However, after this initial (unmapped) surface,
+	   the "real" application surface is opened. This leads to
+	   these applications' startup sequences being interrupted by
+	   Cage exiting. Hence, to work around this issue, Cage checks
+	   whether an XWayland surface has ever been mapped and exits
+	   only if 1) the XWayland surface has ever been mapped and 2)
+	   this was the last surface Cage manages. */
+	bool ever_been_mapped;
+
 	struct wl_listener destroy;
 	struct wl_listener unmap;
 	struct wl_listener map;


### PR DESCRIPTION
This PR introduces a proper abstraction for views, with an interface and two implementations; one for XDG shell and another for XWayland. This cleans up some of the codebase, in my opinion, and makes it more extensible for [damage tracking](https://github.com/Hjdskes/cage/pull/31).

It also properly fixes our issue with XWayland surfaces during application startup.