### PR TITLE
view: don't position override-redirect windows

### DIFF
--- a/view.c
+++ b/view.c
@@ -104,7 +104,15 @@ view_map(struct cg_view *view, struct wlr_surface *surface)
 {
 	view->wlr_surface = surface;
 
-	view_position(view);
+#if CAGE_HAS_XWAYLAND
+	/* We shouldn't position override-redirect windows. They set
+	   their own (x,y) coordinates in handle_wayland_surface_new. */
+	if (view->type != CAGE_XWAYLAND_VIEW ||
+	    !xwayland_view_from_view(view)->xwayland_surface->override_redirect)
+#endif
+	{
+		view_position(view);
+	}
 
 	wl_list_insert(&view->server->views, &view->link);
 	seat_set_focus(view->server->seat, view);

--- a/xwayland.c
+++ b/xwayland.c
@@ -158,6 +158,11 @@ handle_xwayland_surface_new(struct wl_listener *listener, void *data)
 
 	view_init(&xwayland_view->view, server, CAGE_XWAYLAND_VIEW, &xwayland_view_impl);
 	xwayland_view->xwayland_surface = xwayland_surface;
+	if (xwayland_surface->override_redirect) {
+		struct cg_view *view = &xwayland_view->view;
+		view->x = xwayland_surface->x;
+		view->y = xwayland_surface->y;
+	}
 
 	xwayland_view->map.notify = handle_xwayland_surface_map;
 	wl_signal_add(&xwayland_surface->events.map, &xwayland_view->map);


### PR DESCRIPTION
Override-redirect windows are meant to be ignored by the X server, at least as far as position goes. Hence, we detect whether we're dealing with such a window and consequently don't position it.

This makes, amongst others, Chromium's popup menus and dmenu appear on the correct position and size.