### PR TITLE
Implement xdg-decoration

### DIFF
--- a/server.h
+++ b/server.h
@@ -8,6 +8,7 @@
 #include <wlr/types/wlr_idle.h>
 #include <wlr/types/wlr_idle_inhibit_v1.h>
 #include <wlr/types/wlr_output_layout.h>
+#include <wlr/types/wlr_xdg_decoration_v1.h>
 #if CAGE_HAS_XWAYLAND
 #include <wlr/xwayland.h>
 #endif
@@ -19,8 +20,6 @@
 struct cg_server {
 	struct wl_display *wl_display;
 	struct wlr_backend *backend;
-
-	struct wl_listener new_xdg_shell_surface;
 	struct wl_list views;
 
 	struct cg_seat *seat;
@@ -33,10 +32,13 @@ struct cg_server {
 	struct cg_output *output;
 	struct wl_listener new_output;
 
+	struct wl_listener xdg_toplevel_decoration;
+	struct wl_listener new_xdg_shell_surface;
 #if CAGE_HAS_XWAYLAND
 	struct wl_listener new_xwayland_surface;
 #endif
 
+	bool xdg_decoration;
 #ifdef DEBUG
 	bool debug_damage_tracking;
 #endif

--- a/xdg_shell.h
+++ b/xdg_shell.h
@@ -2,6 +2,7 @@
 #define CG_XDG_SHELL_H
 
 #include <wayland-server.h>
+#include <wlr/types/wlr_xdg_decoration_v1.h>
 #include <wlr/types/wlr_xdg_shell.h>
 
 #include "view.h"
@@ -28,6 +29,15 @@ struct cg_xdg_popup {
 	struct wl_listener new_popup;
 };
 
+struct cg_xdg_decoration {
+	struct wlr_xdg_toplevel_decoration_v1 *wlr_decoration;
+	struct cg_server *server;
+	struct wl_listener destroy;
+	struct wl_listener request_mode;
+};
+
 void handle_xdg_shell_surface_new(struct wl_listener *listener, void *data);
+
+void handle_xdg_toplevel_decoration(struct wl_listener *listener, void *data);
 
 #endif


### PR DESCRIPTION
This commit adds a commandline switch (`-d`) to disable client side decorations, if possible. In this case, Cage will not draw any decorations of its own, in order to maximize screen real estate.

The default behavior remains the same, i.e., if `-d` is not passed, clients will draw their client side decorations, if any.

Fixes #32.