### PR TITLE
Add a Travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,28 @@
+language: c
+os: linux
+
+services:
+  - docker
+
+before_install:
+  # Add the automatically checked out repository to the Docker image.
+  - echo "ADD . /root/cage" >> Dockerfile
+  # Build the Docker image.
+  - docker build -t hjdskes/cage .
+
+script:
+  # Build Cage with AddressSanitizer (incl. LeakSanitizer) and
+  # UndefinedBehaviorSanitizer, which will be instrumented during execution.
+  # TODO: find a nicer way to kill termite in order to get Cage to exit.
+  - docker run hjdskes/cage /bin/bash -c "export CC=gcc && meson build -Db_sanitize=address,undefined && ninja -C build && (sleep 5 && pkill -9 termite) & xvfb-run ./build/cage termite"
+
+  # Build Cage with MemorySanitizer, which will also instrument Cage during
+  # execution. Since we can't use all sanitizers together, we have to duplicate
+  # this process here. TODO: This does not work with GCC.
+  # - docker run hjdskes/cage /bin/bash -c "export CC=gcc && meson build -Db_sanitize=memory && ninja -C build && (sleep 5 && pkill -9 termite) & xvfb-run ./build/cage termite"
+
+after_script:
+  # If Cage ran successfully and without any memory errors or undefined behavior
+  # (in those parts exercised by launching a client and exiting almost
+  # immediately), we run Clang's Static Analyzer on Cage.
+  - docker run hjdskes/cage /bin/bash -c "export CC=clang && meson build && ninja -C build scan-build"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,36 @@
+# This isn't ideal from a CI perspective because we're lacking pinned versions
+# here, but Arch is the only distribution (besides Rawhide) that has new enough
+# dependencies. Eventually, when wlroots becomes less bleeding-edge, we can
+# switch to other images that provide stable package versions.
+FROM archlinux/base:latest
+
+# Install the required packages for compiling wlroots and Cage, and a simple
+# xdg-shell-stable application to launch Cage with.
+RUN pacman -Syu --noconfirm xorg-server-xvfb awk procps-ng termite git bash clang \
+      pkgconf libinput libxkbcommon mesa meson pixman libsystemd wayland \
+      wayland-protocols xcb-util-image xcb-util-wm  xcb-util-errors \
+  && pacman -Scc --noconfirm
+
+# Install wlroots, which is required by Cage. Note that we compile a tagged
+# version, instead of master, to avoid any breaking changes in wlroots.
+RUN git clone https://github.com/swaywm/wlroots.git \
+  && cd wlroots \
+  && git checkout tags/0.4.1 \
+  && meson build --prefix=/usr \
+                 -Dlibcap=disabled \
+                 -Dlogind=enabled \
+                 -Dxcb-errors=enabled \
+                 -Dxcb-icccm=enabled \
+                 -Dxwayland=disabled \
+                 -Dx11-backend=enabled \
+                 -Drootston=false \
+                 -Dexamples=false \
+  && ninja -C build \
+  && ninja -C build install
+
+# Cage's (or actually, wlroots') logind session expects XDG_RUNTIME_DIR to be
+# set.
+ENV XDG_RUNTIME_DIR=/tmp
+
+# We have Travis place the clone in this directory, so we need to cd to it.
+WORKDIR /root/cage

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Cage: a Wayland kiosk
+# Cage: a Wayland kiosk [![Build Status](https://travis-ci.com/Hjdskes/cage.svg?branch=master)](https://travis-ci.com/Hjdskes/cage)
 
 This is Cage, a Wayland kiosk. A kiosk runs a single, maximized
 application.


### PR DESCRIPTION
This isn't an optimal build:

1. We're using an untagged, rolling Arch Linux base image for our Docker image, meaning that potentially every build uses a different base. The reason for using an Arch base is because Arch is the only system that has new enough versions of wlroots' dependencies. Alpine has this too, but is sufficiently different (e.g. musl and no logind) from other systems such that I'm not sure whether it will be of any benefit. In the future, when wlroots is less bleeding edge, we can switch to tagged releases of e.g. Fedora.

2. We don't have access to hardware, hence we cannot run with wlroots' headless backend. We can solve this by making the hardware available to our container with docker's `--device=/dev/dri/renderD128`, but we don't have control over this inside our Travis instance. Hence, we need to run with wlroots' x11 backend through xvfb.

Still, it's better than nothing and we will at least get to know whether Cage builds and can start up, open a window and close. For good measure, I also threw in Clang's analyses so we'll learn about potential issues here as well.