### PR TITLE
Implement output transform

### DIFF
--- a/cage.c
+++ b/cage.c
@@ -87,6 +87,7 @@ usage(FILE *file, const char *cage)
 	fprintf(file, "Usage: %s [OPTIONS] [--] APPLICATION\n"
 		"\n"
 		" -d\t Don't draw client side decorations, when possible\n"
+		" -r\t Rotate the output 90 degrees clockwise, specify up to three times\n"
 #ifdef DEBUG
 		" -D\t Turn on damage tracking debugging\n"
 #endif
@@ -101,13 +102,19 @@ parse_args(struct cg_server *server, int argc, char *argv[])
 {
 	int c;
 #ifdef DEBUG
-	while ((c = getopt(argc, argv, "dDh")) != -1) {
+	while ((c = getopt(argc, argv, "drDh")) != -1) {
 #else
-	while ((c = getopt(argc, argv, "dh")) != -1) {
+	while ((c = getopt(argc, argv, "drh")) != -1) {
 #endif
 		switch (c) {
 		case 'd':
 			server->xdg_decoration = true;
+			break;
+		case 'r':
+			server->output_transform++;
+			if (server->output_transform > WL_OUTPUT_TRANSFORM_270) {
+				server->output_transform = WL_OUTPUT_TRANSFORM_NORMAL;
+			}
 			break;
 #ifdef DEBUG
 		case 'D':

--- a/output.c
+++ b/output.c
@@ -211,10 +211,7 @@ handle_output_damage_frame(struct wl_listener *listener, void *data)
 		goto damage_finish;
 	}
 
-	int output_width, output_height;
-	wlr_output_transformed_resolution(output->wlr_output, &output_width, &output_height);
-
-	wlr_renderer_begin(renderer, output_width, output_height);
+	wlr_renderer_begin(renderer, output->wlr_output->width, output->wlr_output->height);
 
 	if (!pixman_region32_not_empty(&damage)) {
 		wlr_log(WLR_DEBUG, "Output isn't damaged but needs a buffer swap");
@@ -257,6 +254,9 @@ handle_output_damage_frame(struct wl_listener *listener, void *data)
 	wlr_output_render_software_cursors(output->wlr_output, &damage);
 	wlr_renderer_scissor(renderer, NULL);
 	wlr_renderer_end(renderer);
+
+	int output_width, output_height;
+	wlr_output_transformed_resolution(output->wlr_output, &output_width, &output_height);
 
 #ifdef DEBUG
 	if (output->server->debug_damage_tracking) {
@@ -365,6 +365,8 @@ handle_new_output(struct wl_listener *listener, void *data)
 	wl_signal_add(&server->output->damage->events.frame, &server->output->damage_frame);
 	server->output->damage_destroy.notify = handle_output_damage_destroy;
 	wl_signal_add(&server->output->damage->events.destroy, &server->output->damage_destroy);
+
+	wlr_output_set_transform(wlr_output, server->output_transform);
 
 	wlr_output_layout_add_auto(server->output_layout, wlr_output);
 

--- a/seat.c
+++ b/seat.c
@@ -157,6 +157,8 @@ handle_new_touch(struct cg_seat *seat, struct wlr_input_device *device)
 	wl_list_insert(&seat->touch, &touch->link);
 	touch->destroy.notify = handle_touch_destroy;
 	wl_signal_add(&touch->device->events.destroy, &touch->destroy);
+
+	wlr_cursor_map_input_to_output(seat->cursor, device, seat->server->output->wlr_output);
 }
 
 static void
@@ -189,6 +191,8 @@ handle_new_pointer(struct cg_seat *seat, struct wlr_input_device *device)
 	wl_list_insert(&seat->pointers, &pointer->link);
 	pointer->destroy.notify = handle_pointer_destroy;
 	wl_signal_add(&device->events.destroy, &pointer->destroy);
+
+	wlr_cursor_map_input_to_output(seat->cursor, device, seat->server->output->wlr_output);
 }
 
 static void

--- a/server.h
+++ b/server.h
@@ -39,6 +39,7 @@ struct cg_server {
 #endif
 
 	bool xdg_decoration;
+	enum wl_output_transform output_transform;
 #ifdef DEBUG
 	bool debug_damage_tracking;
 #endif


### PR DESCRIPTION
This commit adds two command line switches. -r rotates the output 90
degrees clockwise and can be specified multiple times. -f flips the
output.

Fixes #55