### PR TITLE
Add Sourcehut CI builds

### DIFF
--- a/.builds/alpine.yml
+++ b/.builds/alpine.yml
@@ -1,0 +1,28 @@
+image: alpine/edge
+packages:
+  - eudev-dev
+  - mesa-dev
+  - meson
+  - libinput-dev
+  - libxkbcommon-dev
+  - pixman-dev
+  - wayland-dev
+  - wayland-protocols
+  - xorg-server-xwayland
+sources:
+  - https://github.com/swaywm/wlroots
+  - https://github.com/Hjdskes/cage
+tasks:
+  # Install wlroots, which is required by Cage. Note that we compile a tagged
+  # version, instead of master, to avoid any breaking changes in wlroots.
+  - wlroots: |
+      cd wlroots
+      # This corresponds to the tag of 0.5.0
+      git checkout c9137cba691b57c3eaf3ff94f9bf8e623f66ccc5
+      meson --prefix=/usr build -Drootston=false -Dexamples=false
+      ninja -C build
+      sudo ninja -C build install
+  - build: |
+      cd cage
+      meson build -Dxwayland=true
+      ninja -C build

--- a/.builds/archlinux.yml
+++ b/.builds/archlinux.yml
@@ -1,0 +1,30 @@
+image: archlinux
+packages:
+  - clang
+  - meson
+  - libinput
+  - libxkbcommon
+  - wayland
+  - wayland-protocols
+  - xorg-server-xwayland
+sources:
+  - https://github.com/swaywm/wlroots
+  - https://github.com/Hjdskes/cage
+tasks:
+  # Install wlroots, which is required by Cage. Note that we compile a tagged
+  # version, instead of master, to avoid any breaking changes in wlroots.
+  - wlroots: |
+      cd wlroots
+      # This corresponds to the tag of 0.5.0
+      git checkout c9137cba691b57c3eaf3ff94f9bf8e623f66ccc5
+      meson --prefix=/usr build -Drootston=false -Dexamples=false
+      ninja -C build
+      sudo ninja -C build install
+  - build: |
+      cd cage
+      meson build -Dxwayland=true
+      ninja -C build
+  - scan-build: |
+      cd cage
+      CC=clang meson build -Dxwayland=true
+      CC=clang ninja -C build scan-build

--- a/.builds/freebsd.yml
+++ b/.builds/freebsd.yml
@@ -1,0 +1,45 @@
+image: freebsd/latest
+packages:
+  - devel/evdev-proto
+  - devel/meson
+  - devel/libepoll-shim
+  - devel/pkgconf
+  - graphics/mesa-libs
+  - graphics/wayland
+  - graphics/wayland-protocols
+  - x11/libinput
+  - x11/libxkbcommon
+  - x11/pixman
+sources:
+  - https://github.com/swaywm/wlroots
+  - https://github.com/Hjdskes/cage
+tasks:
+  # Taken from sway
+  - fixup_epoll: |
+      cat << 'EOF' | sudo tee /usr/local/libdata/pkgconfig/epoll-shim.pc
+      prefix=/usr/local
+      exec_prefix=\$\{\$prefix\}
+      libdir=${prefix}/lib
+      sharedlibdir=${prefix}/lib
+      includedir=${prefix}/include/libepoll-shim
+      Name: epoll-shim
+      Description: epoll shim implemented using kevent
+      Version: 0
+      Requires:
+      Libs: -L${libdir} -L${sharedlibdir} -lepoll-shim
+      Libs.private: -pthread -lrt
+      Cflags: -I${includedir}
+      EOF
+  # Install wlroots, which is required by Cage. Note that we compile a tagged
+  # version, instead of master, to avoid any breaking changes in wlroots.
+  - wlroots: |
+      cd wlroots
+      # This corresponds to the tag of 0.5.0
+      git checkout c9137cba691b57c3eaf3ff94f9bf8e623f66ccc5
+      meson --prefix=/usr/local build -Drootston=false -Dexamples=false
+      ninja -C build
+      sudo ninja -C build install
+  - build: |
+      cd cage
+      PKG_CONFIG_PATH=/usr/local/lib/pkgconfig meson build -Dxwayland=true
+      PKG_CONFIG_PATH=/usr/local/lib/pkgconfig ninja -C build

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Cage: a Wayland kiosk
+# Cage: a Wayland kiosk [![builds.sr.ht status](https://builds.sr.ht/~hjdskes.svg)](https://builds.sr.ht/~hjdskes?)
 
 This is Cage, a Wayland kiosk. A kiosk runs a single, maximized
 application.

--- a/cage.c
+++ b/cage.c
@@ -290,7 +290,7 @@ main(int argc, char *argv[])
 		wlr_log_errno(WLR_ERROR, "Unable to set DISPLAY for XWayland.",
 			      "Clients may not be able to connect");
 	} else {
-		wlr_log(WLR_DEBUG, "XWayland is running on display %s", socket);
+		wlr_log(WLR_DEBUG, "XWayland is running on display %s", xwayland->display_name);
 	}
 
 	if (wlr_xcursor_manager_load(xcursor_manager, 1)) {

--- a/meson.build
+++ b/meson.build
@@ -24,6 +24,17 @@ endif
 
 cc = meson.get_compiler('c')
 
+is_freebsd = host_machine.system().startswith('freebsd')
+if is_freebsd
+  add_project_arguments(
+    [
+      '-Wno-format-extra-args',
+      '-Wno-gnu-zero-variadic-macro-arguments',
+    ],
+    language: 'c'
+  )
+endif
+
 wlroots        = dependency('wlroots', version: '>= 0.5.0')
 wayland_protos = dependency('wayland-protocols', version: '>=1.14')
 wayland_server = dependency('wayland-server')

--- a/output.c
+++ b/output.c
@@ -55,7 +55,7 @@ scissor_output(struct wlr_output *output, pixman_box32_t *rect)
 }
 
 static void
-send_frame_done(struct wlr_surface *surface, int _unused, int __unused, void *data)
+send_frame_done(struct wlr_surface *surface, int _unused, int _not_used, void *data)
 {
 	struct timespec *now = data;
 	wlr_surface_send_frame_done(surface, now);


### PR DESCRIPTION
After [Drew's generous offer](https://github.com/Hjdskes/cage/pull/50#issuecomment-481702208), I hooked up a Sourcehut CI instead of Travis. Sourcehut solves the problem where we don't have access to hardware and are thus forced to use xvfb.

We're still using a rolling Arch image, but it is sufficiently easier compared to Travis. As a result, we now also build on Alpine *and* FreeBSD, so we get better coverage over different stacks as well (and compilers, since FreeBSD uses Clang). This has already resulted in two small fixes in Cage, as seen in this PR.

I have taken out the sanitizers for now, since I was running into issues inside mesa. For these I have opened a [bug report](https://bugs.freedesktop.org/show_bug.cgi?id=110479); once this is fixed I will look into adding the sanitizers again.