### PR TITLE
Set version to 0.1

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('cage', 'c',
-  version: '0.0.1',
+  version: '0.1',
   license: 'MIT',
   default_options: [
     'c_std=c11',


### PR DESCRIPTION
Since we now have a tag with 0.1 and also a release with that version
number was published on GitHub we should adjust the version in the meson
file too.