### PR TITLE
Drop fixup_epoll in .builds/freebsd.yml

### DIFF
--- a/.builds/freebsd.yml
+++ b/.builds/freebsd.yml
@@ -14,22 +14,6 @@ sources:
   - https://github.com/swaywm/wlroots
   - https://github.com/Hjdskes/cage
 tasks:
-  # Taken from sway
-  - fixup_epoll: |
-      cat << 'EOF' | sudo tee /usr/local/libdata/pkgconfig/epoll-shim.pc
-      prefix=/usr/local
-      exec_prefix=\$\{\$prefix\}
-      libdir=${prefix}/lib
-      sharedlibdir=${prefix}/lib
-      includedir=${prefix}/include/libepoll-shim
-      Name: epoll-shim
-      Description: epoll shim implemented using kevent
-      Version: 0
-      Requires:
-      Libs: -L${libdir} -L${sharedlibdir} -lepoll-shim
-      Libs.private: -pthread -lrt
-      Cflags: -I${includedir}
-      EOF
   # Install wlroots, which is required by Cage. Note that we compile a tagged
   # version, instead of master, to avoid any breaking changes in wlroots.
   - wlroots: |


### PR DESCRIPTION
`/latest` has `epoll-shim.pc` after https://github.com/freebsd/freebsd-ports/commit/68b90c9df610ee3d99c719360256fcacf2e83603. Same as https://github.com/swaywm/wlroots/pull/1671.