### PR TITLE
Support multiple outputs

### DIFF
--- a/cage.c
+++ b/cage.c
@@ -220,6 +220,7 @@ main(int argc, char *argv[])
 	wlr_renderer_init_wl_display(renderer, server.wl_display);
 
 	wl_list_init(&server.views);
+	wl_list_init(&server.outputs);
 
 	server.output_layout = wlr_output_layout_create();
 	if (!server.output_layout) {

--- a/output.c
+++ b/output.c
@@ -363,6 +363,10 @@ handle_new_output(struct wl_listener *listener, void *data)
 	}
 
 	struct cg_output *output = calloc(1, sizeof(struct cg_output));
+	if (!output) {
+		return;
+	}
+
 	output->wlr_output = wlr_output;
 	output->server = server;
 	output->damage = wlr_output_damage_create(wlr_output);

--- a/output.c
+++ b/output.c
@@ -207,7 +207,6 @@ handle_output_damage_frame(struct wl_listener *listener, void *data)
 	}
 
 	if (!needs_frame) {
-		wlr_log(WLR_DEBUG, "Output doesn't need frame and isn't damaged");
 		goto buffer_damage_finish;
 	}
 

--- a/output.h
+++ b/output.h
@@ -20,7 +20,7 @@ struct cg_output {
 	struct wl_listener damage_frame;
 	struct wl_listener damage_destroy;
 
-	struct wl_list link;
+	struct wl_list link; // cg_server::outputs
 };
 
 void handle_new_output(struct wl_listener *listener, void *data);

--- a/output.h
+++ b/output.h
@@ -19,6 +19,8 @@ struct cg_output {
 	struct wl_listener destroy;
 	struct wl_listener damage_frame;
 	struct wl_listener damage_destroy;
+
+	struct wl_list link;
 };
 
 void handle_new_output(struct wl_listener *listener, void *data);

--- a/seat.c
+++ b/seat.c
@@ -158,7 +158,15 @@ handle_new_touch(struct cg_seat *seat, struct wlr_input_device *device)
 	touch->destroy.notify = handle_touch_destroy;
 	wl_signal_add(&touch->device->events.destroy, &touch->destroy);
 
-	wlr_cursor_map_input_to_output(seat->cursor, device, seat->server->output->wlr_output);
+	if (device->output_name != NULL) {
+		struct cg_output *output;
+		wl_list_for_each(output, &seat->server->outputs, link) {
+			if (strcmp(device->output_name, output->wlr_output->name) == 0) {
+				wlr_cursor_map_input_to_output(seat->cursor, device, output->wlr_output);
+				break;
+			}
+		}
+	}
 }
 
 static void
@@ -192,7 +200,15 @@ handle_new_pointer(struct cg_seat *seat, struct wlr_input_device *device)
 	pointer->destroy.notify = handle_pointer_destroy;
 	wl_signal_add(&device->events.destroy, &pointer->destroy);
 
-	wlr_cursor_map_input_to_output(seat->cursor, device, seat->server->output->wlr_output);
+	if (device->output_name != NULL) {
+		struct cg_output *output;
+		wl_list_for_each(output, &seat->server->outputs, link) {
+			if (strcmp(device->output_name, output->wlr_output->name) == 0) {
+				wlr_cursor_map_input_to_output(seat->cursor, device, output->wlr_output);
+				break;
+			}
+		}
+	}
 }
 
 static void
@@ -568,7 +584,10 @@ handle_cursor_motion(struct wl_listener *listener, void *data)
 static void
 drag_icon_damage(struct cg_drag_icon *drag_icon)
 {
-	output_damage_drag_icon(drag_icon->seat->server->output, drag_icon);
+	struct cg_output *output;
+	wl_list_for_each(output, &drag_icon->seat->server->outputs, link) {
+		output_damage_drag_icon(output, drag_icon);
+	}
 }
 
 static void
@@ -835,7 +854,10 @@ seat_set_focus(struct cg_seat *seat, struct cg_view *view)
 
 	view_activate(view, true);
 	char *title = view_get_title(view);
-	output_set_window_title(server->output, title);
+	struct cg_output *output;
+	wl_list_for_each(output, &server->outputs, link) {
+		output_set_window_title(output, title);
+	}
 	free(title);
 
 	struct wlr_keyboard *keyboard = wlr_seat_get_keyboard(wlr_seat);

--- a/seat.c
+++ b/seat.c
@@ -853,19 +853,10 @@ seat_set_focus(struct cg_seat *seat, struct cg_view *view)
 	}
 
 	view_activate(view, true);
-
-	struct wlr_box surface_box;
-	wlr_surface_get_extends(view->wlr_surface, &surface_box);
-
 	char *title = view_get_title(view);
 	struct cg_output *output;
 	wl_list_for_each(output, &server->outputs, link) {
-		struct wlr_box *output_box =
-				wlr_output_layout_get_box(view->server->output_layout, output->wlr_output);
-		struct wlr_box intersection;
-		if (wlr_box_intersection(&intersection, &surface_box, output_box)) {
-			output_set_window_title(output, title);
-		}
+		output_set_window_title(output, title);
 	}
 	free(title);
 

--- a/seat.c
+++ b/seat.c
@@ -853,10 +853,19 @@ seat_set_focus(struct cg_seat *seat, struct cg_view *view)
 	}
 
 	view_activate(view, true);
+
+	struct wlr_box surface_box;
+	wlr_surface_get_extends(view->wlr_surface, &surface_box);
+
 	char *title = view_get_title(view);
 	struct cg_output *output;
 	wl_list_for_each(output, &server->outputs, link) {
-		output_set_window_title(output, title);
+		struct wlr_box *output_box =
+				wlr_output_layout_get_box(view->server->output_layout, output->wlr_output);
+		struct wlr_box intersection;
+		if (wlr_box_intersection(&intersection, &surface_box, output_box)) {
+			output_set_window_title(output, title);
+		}
 	}
 	free(title);
 

--- a/server.h
+++ b/server.h
@@ -29,7 +29,7 @@ struct cg_server {
 	struct wl_list inhibitors;
 
 	struct wlr_output_layout *output_layout;
-	struct cg_output *output;
+	struct wl_list outputs;
 	struct wl_listener new_output;
 
 	struct wl_listener xdg_toplevel_decoration;

--- a/xdg_shell.c
+++ b/xdg_shell.c
@@ -93,10 +93,12 @@ static void
 popup_unconstrain(struct cg_xdg_popup *popup)
 {
 	struct cg_view *view = popup->view_child.view;
-	struct wlr_output *output = view->server->output->wlr_output;
-	struct wlr_output_layout *output_layout = view->server->output_layout;
+	struct cg_server *server = view->server;
+	struct wlr_box *popup_box = &popup->wlr_popup->geometry;
 
-	struct wlr_box *output_box = wlr_output_layout_get_box(output_layout, output);
+	struct wlr_output_layout *output_layout = server->output_layout;
+	struct wlr_output *wlr_output = wlr_output_layout_output_at(output_layout, view->x + popup_box->x, view->y + popup_box->y);
+	struct wlr_box *output_box = wlr_output_layout_get_box(output_layout, wlr_output);
 
 	struct wlr_box output_toplevel_box = {
 		.x = output_box->x - view->x,


### PR DESCRIPTION
Outputs are arranged in a horizontal layout in the order they are
created in by wlroots. Maximized xdg_shell views will span all outputs,
like the global fullscreen mode in sway.

Fixes #87