### PR TITLE
Update new output handler for wlroots 0.9.0

### DIFF
--- a/output.c
+++ b/output.c
@@ -401,6 +401,9 @@ handle_new_output(struct wl_listener *listener, void *data)
 	/* Place the cursor in the center of the screen. */
 	wlr_cursor_warp(server->seat->cursor, NULL, wlr_output->width / 2, wlr_output->height / 2);
 	wlr_output_damage_add_whole(output->damage);
+
+	wlr_output_enable(wlr_output, true);
+	wlr_output_commit(wlr_output);
 }
 
 void


### PR DESCRIPTION
Following breaking changes in wlroots 0.9.0, `wlr_output_commit` must be
called after `wlr_output_set_mode`, `wlr_output_set_transform` and `wlr_output_enable`.
Additionally, `wlr_output_enable` is no longer implicitly called by
`wlr_output_set_mode`.

Fixes #102