### PR TITLE
CI: build against wlroots 0.10.0

### DIFF
--- a/.builds/alpine.yml
+++ b/.builds/alpine.yml
@@ -17,7 +17,7 @@ tasks:
   # version, instead of master, to avoid any breaking changes in wlroots.
   - wlroots: |
       cd wlroots
-      git checkout 0.9.1
+      git checkout 0.10.0
       meson --prefix=/usr build -Dexamples=false
       ninja -C build
       sudo ninja -C build install

--- a/.builds/archlinux.yml
+++ b/.builds/archlinux.yml
@@ -15,7 +15,7 @@ tasks:
   # version, instead of master, to avoid any breaking changes in wlroots.
   - wlroots: |
       cd wlroots
-      git checkout 0.9.1
+      git checkout 0.10.0
       meson --prefix=/usr build -Dexamples=false
       ninja -C build
       sudo ninja -C build install

--- a/.builds/freebsd.yml
+++ b/.builds/freebsd.yml
@@ -18,7 +18,7 @@ tasks:
   # version, instead of master, to avoid any breaking changes in wlroots.
   - wlroots: |
       cd wlroots
-      git checkout 0.9.1
+      git checkout 0.10.0
       meson --prefix=/usr/local build -Dexamples=false
       ninja -C build
       sudo ninja -C build install


### PR DESCRIPTION
There are no breaking changes otherwise, so in meson.build we can leave
the version to anything greater than 0.9.1.