### PR TITLE
Check if XDG_RUNTIME_DIR is set

### DIFF
--- a/cage.c
+++ b/cage.c
@@ -194,6 +194,12 @@ main(int argc, char *argv[])
 	wlr_log_init(WLR_ERROR, NULL);
 #endif
 
+	/* Wayland requires XDG_RUNTIME_DIR to be set. */
+	if (!getenv("XDG_RUNTIME_DIR")) {
+		wlr_log(WLR_ERROR, "XDG_RUNTIME_DIR is not set in the environment");
+		return 1;
+	}
+
 	server.wl_display = wl_display_create();
 	if (!server.wl_display) {
 		wlr_log(WLR_ERROR, "Cannot allocate a Wayland display");


### PR DESCRIPTION
Wayland requires this environment variable to be set, see
https://manpages.debian.org/experimental/libwayland-doc/wl_display_connect.3.en.html