### PR TITLE
move xwayland.h include to ifdef block for X11

### DIFF
--- a/output.c
+++ b/output.c
@@ -19,6 +19,7 @@
 #include <wlr/backend/wayland.h>
 #if WLR_HAS_X11_BACKEND
 #include <wlr/backend/x11.h>
+#include "xwayland.h"
 #endif
 #include <wlr/render/wlr_renderer.h>
 #include <wlr/types/wlr_data_device.h>
@@ -36,7 +37,6 @@
 #include "server.h"
 #include "util.h"
 #include "view.h"
-#include "xwayland.h"
 
 static void output_for_each_surface(struct cg_output *output, cg_surface_iterator_func_t iterator, void *user_data);
 

--- a/output.c
+++ b/output.c
@@ -19,7 +19,6 @@
 #include <wlr/backend/wayland.h>
 #if WLR_HAS_X11_BACKEND
 #include <wlr/backend/x11.h>
-#include "xwayland.h"
 #endif
 #include <wlr/render/wlr_renderer.h>
 #include <wlr/types/wlr_data_device.h>
@@ -37,6 +36,9 @@
 #include "server.h"
 #include "util.h"
 #include "view.h"
+#if CAGE_HAS_XWAYLAND
+#include "xwayland.h"
+#endif
 
 static void output_for_each_surface(struct cg_output *output, cg_surface_iterator_func_t iterator, void *user_data);
 


### PR DESCRIPTION
Moved the include for xwayland.h into the if def block so it will build without X. It works on pure wayland but have not tested on a system with Xwayland.