### PR TITLE
Implement support for wlr_keyboard_group

### DIFF
--- a/seat.c
+++ b/seat.c
@@ -314,12 +314,6 @@ cg_keyboard_group_add(struct wlr_input_device *device, struct cg_seat *seat)
 
 	wlr_log(WLR_DEBUG, "Created keyboard group");
 
-	cg_group->keyboard = &cg_group->wlr_group->keyboard;
-	if (cg_group->keyboard == NULL) {
-		wlr_log(WLR_ERROR, "Failed to create keyboard from seat.");
-		goto cleanup;
-	}
-
 	wlr_keyboard_group_add_keyboard(cg_group->wlr_group, wlr_keyboard);
 	wl_list_insert(&seat->keyboard_groups, &cg_group->link);
 

--- a/seat.c
+++ b/seat.c
@@ -212,8 +212,7 @@ static void
 handle_modifier_event(struct wlr_input_device *device, struct cg_seat *seat)
 {
 	wlr_seat_set_keyboard(seat->seat, device);
-	wlr_seat_keyboard_notify_modifiers(seat->seat,
-					   &device->keyboard->modifiers);
+	wlr_seat_keyboard_notify_modifiers(seat->seat, &device->keyboard->modifiers);
 
 	wlr_idle_notify_activity(seat->server->idle, seat->seat);
 }
@@ -235,7 +234,7 @@ handle_keybinding(struct cg_server *server, xkb_keysym_t sym)
 }
 
 static void
-handle_key_event(struct wlr_input_device *device, struct cg_seat* seat, void *data)
+handle_key_event(struct wlr_input_device *device, struct cg_seat *seat, void *data)
 {
 	struct wlr_event_keyboard_key *event = data;
 
@@ -259,15 +258,15 @@ handle_key_event(struct wlr_input_device *device, struct cg_seat* seat, void *da
 	if (!handled) {
 		/* Otherwise, we pass it along to the client. */
 		wlr_seat_set_keyboard(seat->seat, device);
-		wlr_seat_keyboard_notify_key(seat->seat, event->time_msec,
-					     event->keycode, event->state);
+		wlr_seat_keyboard_notify_key(seat->seat, event->time_msec, event->keycode, event->state);
 	}
 
 	wlr_idle_notify_activity(seat->server->idle, seat->seat);
 }
 
 static void
-handle_keyboard_group_key(struct wl_listener *listener, void *data) {
+handle_keyboard_group_key(struct wl_listener *listener, void *data)
+{
 	struct cg_keyboard_group *cg_group = wl_container_of(listener, cg_group, key);
 	handle_key_event(cg_group->wlr_group->input_device, cg_group->seat, data);
 }
@@ -280,12 +279,12 @@ handle_keyboard_group_modifiers(struct wl_listener *listener, void *data)
 }
 
 static void
-cg_keyboard_group_add(struct wlr_input_device *device, struct cg_seat* seat)
+cg_keyboard_group_add(struct wlr_input_device *device, struct cg_seat *seat)
 {
 	struct wlr_keyboard *wlr_keyboard = device->keyboard;
 
 	struct cg_keyboard_group *group;
-	wl_list_for_each(group, &seat->keyboard_groups, link) {
+	wl_list_for_each (group, &seat->keyboard_groups, link) {
 		struct wlr_keyboard_group *wlr_group = group->wlr_group;
 		if (wlr_keyboard_group_add_keyboard(wlr_group, wlr_keyboard)) {
 			wlr_log(WLR_DEBUG, "Added new keyboard to existing group");
@@ -295,8 +294,7 @@ cg_keyboard_group_add(struct wlr_input_device *device, struct cg_seat* seat)
 
 	/* This is reached if and only if the keyboard could not be inserted into
 	 * any group */
-	struct cg_keyboard_group *cg_group =
-	    calloc(1, sizeof(struct cg_keyboard_group));
+	struct cg_keyboard_group *cg_group = calloc(1, sizeof(struct cg_keyboard_group));
 	cg_group->seat = seat;
 	if (cg_group == NULL) {
 		wlr_log(WLR_ERROR, "Failed to allocate keyboard group.");
@@ -309,11 +307,10 @@ cg_keyboard_group_add(struct wlr_input_device *device, struct cg_seat* seat)
 	}
 
 	cg_group->wlr_group->data = cg_group;
-	wlr_keyboard_set_keymap(&cg_group->wlr_group->keyboard,
-	                        device->keyboard->keymap);
+	wlr_keyboard_set_keymap(&cg_group->wlr_group->keyboard, device->keyboard->keymap);
 
-	wlr_keyboard_set_repeat_info(&cg_group->wlr_group->keyboard,
-			wlr_keyboard->repeat_info.rate, wlr_keyboard->repeat_info.delay);
+	wlr_keyboard_set_repeat_info(&cg_group->wlr_group->keyboard, wlr_keyboard->repeat_info.rate,
+				     wlr_keyboard->repeat_info.delay);
 
 	wlr_log(WLR_DEBUG, "Created keyboard group");
 
@@ -328,8 +325,7 @@ cg_keyboard_group_add(struct wlr_input_device *device, struct cg_seat* seat)
 
 	wl_signal_add(&cg_group->wlr_group->keyboard.events.key, &cg_group->key);
 	cg_group->key.notify = handle_keyboard_group_key;
-	wl_signal_add(&cg_group->wlr_group->keyboard.events.modifiers,
-	              &cg_group->modifiers);
+	wl_signal_add(&cg_group->wlr_group->keyboard.events.modifiers, &cg_group->modifiers);
 	cg_group->modifiers.notify = handle_keyboard_group_modifiers;
 
 	return;
@@ -703,7 +699,7 @@ handle_destroy(struct wl_listener *listener, void *data)
 	wl_list_remove(&seat->destroy.link);
 
 	struct cg_keyboard_group *group, *group_tmp;
-	wl_list_for_each_safe(group, group_tmp, &seat->keyboard_groups, link) {
+	wl_list_for_each_safe (group, group_tmp, &seat->keyboard_groups, link) {
 		wlr_keyboard_group_destroy(group->wlr_group);
 		free(group);
 	}

--- a/seat.c
+++ b/seat.c
@@ -288,8 +288,7 @@ cg_keyboard_group_remove_keyboard(struct cg_keyboard *keyboard)
 {
 	struct wlr_keyboard_group *wlr_group = keyboard->device->keyboard->group;
 
-	wlr_keyboard_group_remove_keyboard(keyboard->device->keyboard->group,
-	                                   keyboard->device->keyboard);
+	wlr_keyboard_group_remove_keyboard(wlr_group, keyboard->device->keyboard);
 
 	if (wl_list_empty(&wlr_group->devices)) {
 		wlr_log(WLR_DEBUG, "Destroying empty keyboard group %p", (void*)wlr_group);

--- a/seat.c
+++ b/seat.c
@@ -298,7 +298,7 @@ cg_keyboard_group_remove(struct cg_keyboard *keyboard)
 	                                   keyboard->device->keyboard);
 
 	if (wl_list_empty(&wlr_group->devices)) {
-		wlr_log(WLR_DEBUG, "Destroying empty keyboard group %p", wlr_group);
+		wlr_log(WLR_DEBUG, "Destroying empty keyboard group %p", (void*)wlr_group);
 		struct cg_keyboard_group *cg_group = wlr_group->data;
 		wlr_group->data = NULL;
 		wl_list_remove(&cg_group->link);
@@ -376,8 +376,8 @@ keyboard_group_add(struct cg_keyboard *keyboard) {
 		struct wlr_keyboard_group *wlr_group = group->wlr_group;
 		if (keymaps_match(wlr_keyboard->keymap, wlr_group->keyboard.keymap) &&
 		   repeat_info_match(keyboard, &wlr_group->keyboard)) {
-			wlr_log(WLR_DEBUG, "Adding keyboard %p to group %p.", keyboard,
-			        wlr_group);
+			wlr_log(WLR_DEBUG, "Adding keyboard %p to group %p.", (void*)keyboard,
+			        (void*)wlr_group);
 			wlr_keyboard_group_add_keyboard(wlr_group, wlr_keyboard);
 			return;
 		}
@@ -399,7 +399,7 @@ keyboard_group_add(struct cg_keyboard *keyboard) {
 	cg_group->wlr_group->data = cg_group;
 	wlr_keyboard_set_keymap(&cg_group->wlr_group->keyboard,
 	                        keyboard->device->keyboard->keymap);
-	wlr_log(WLR_DEBUG, "Created keyboard group %p", cg_group->wlr_group);
+	wlr_log(WLR_DEBUG, "Created keyboard group %p", (void*)cg_group->wlr_group);
 
 	cg_group->keyboard =
 	    cg_keyboard_from_seat(seat, cg_group->wlr_group->input_device);
@@ -408,8 +408,8 @@ keyboard_group_add(struct cg_keyboard *keyboard) {
 		goto cleanup;
 	}
 
-	wlr_log(WLR_DEBUG, "Adding keyboard %p to group %p.", keyboard,
-	        cg_group->wlr_group);
+	wlr_log(WLR_DEBUG, "Adding keyboard %p to group %p.", (void*)keyboard,
+	        (void*)cg_group->wlr_group);
 	wlr_keyboard_group_add_keyboard(cg_group->wlr_group, wlr_keyboard);
 	wl_list_insert(&seat->keyboard_groups, &cg_group->link);
 

--- a/seat.c
+++ b/seat.c
@@ -394,10 +394,10 @@ cg_keyboard_group_add(struct cg_keyboard *keyboard)
 
 	wl_signal_add(&cg_group->wlr_group->keyboard.events.key, &cg_group->key);
 	cg_group->key.notify = handle_keyboard_group_key;
-
 	wl_signal_add(&cg_group->wlr_group->keyboard.events.modifiers,
 	              &cg_group->modifiers);
 	cg_group->modifiers.notify = handle_keyboard_group_modifiers;
+
 	return;
 
 cleanup:

--- a/seat.c
+++ b/seat.c
@@ -445,7 +445,7 @@ handle_new_keyboard(struct cg_seat *seat, struct wlr_input_device *device)
 	xkb_context_unref(context);
 	wlr_keyboard_set_repeat_info(device->keyboard, 25, 600);
 
-	keyboard_group_add(keyboard);
+	cg_keyboard_group_add(keyboard);
 
 	wl_list_insert(&seat->keyboards, &keyboard->link);
 	keyboard->destroy.notify = handle_keyboard_destroy;

--- a/seat.c
+++ b/seat.c
@@ -291,7 +291,7 @@ cg_keyboard_group_remove_keyboard(struct cg_keyboard *keyboard)
 	wlr_keyboard_group_remove_keyboard(wlr_group, keyboard->device->keyboard);
 
 	if (wl_list_empty(&wlr_group->devices)) {
-		wlr_log(WLR_DEBUG, "Destroying empty keyboard group %p", (void*)wlr_group);
+		wlr_log(WLR_DEBUG, "Destroying empty keyboard group");
 		struct cg_keyboard_group *cg_group = wlr_group->data;
 		wlr_group->data = NULL;
 		wl_list_remove(&cg_group->link);

--- a/seat.c
+++ b/seat.c
@@ -295,11 +295,11 @@ cg_keyboard_group_add(struct wlr_input_device *device, struct cg_seat *seat)
 	/* This is reached if and only if the keyboard could not be inserted into
 	 * any group */
 	struct cg_keyboard_group *cg_group = calloc(1, sizeof(struct cg_keyboard_group));
-	cg_group->seat = seat;
 	if (cg_group == NULL) {
 		wlr_log(WLR_ERROR, "Failed to allocate keyboard group.");
 		return;
 	}
+	cg_group->seat = seat;
 	cg_group->wlr_group = wlr_keyboard_group_create();
 	if (cg_group->wlr_group == NULL) {
 		wlr_log(WLR_ERROR, "Failed to create wlr keyboard group.");

--- a/seat.c
+++ b/seat.c
@@ -345,10 +345,11 @@ cg_keyboard_from_seat(struct cg_seat *seat, struct wlr_input_device *device)
 }
 
 static void
-keyboard_group_add(struct cg_keyboard *keyboard)
+cg_keyboard_group_add(struct cg_keyboard *keyboard)
 {
 	struct cg_seat *seat = keyboard->seat;
 	struct wlr_keyboard *wlr_keyboard = keyboard->device->keyboard;
+
 	struct cg_keyboard_group *group;
 	wl_list_for_each(group, &seat->keyboard_groups, link) {
 		struct wlr_keyboard_group *wlr_group = group->wlr_group;
@@ -357,6 +358,7 @@ keyboard_group_add(struct cg_keyboard *keyboard)
 			return;
 		}
 	}
+
 	/* This is reached if and only if the keyboard could not be inserted into
 	 * any group */
 	struct cg_keyboard_group *cg_group =
@@ -374,6 +376,10 @@ keyboard_group_add(struct cg_keyboard *keyboard)
 	cg_group->wlr_group->data = cg_group;
 	wlr_keyboard_set_keymap(&cg_group->wlr_group->keyboard,
 	                        keyboard->device->keyboard->keymap);
+
+	wlr_keyboard_set_repeat_info(&cg_group->wlr_group->keyboard,
+			wlr_keyboard->repeat_info.rate, wlr_keyboard->repeat_info.delay);
+
 	wlr_log(WLR_DEBUG, "Created keyboard group");
 
 	cg_group->keyboard =

--- a/seat.c
+++ b/seat.c
@@ -265,8 +265,7 @@ handle_key_event(struct cg_keyboard *keyboard, void *data)
 	wlr_idle_notify_activity(seat->server->idle, seat->seat);
 }
 
-static void
-cg_keyboard_group_remove(struct cg_keyboard *keyboard);
+static void cg_keyboard_group_remove_keyboard(struct cg_keyboard *keyboard);
 
 static void
 cg_keyboard_destroy(struct cg_keyboard *keyboard)
@@ -274,7 +273,7 @@ cg_keyboard_destroy(struct cg_keyboard *keyboard)
 	struct cg_seat *seat = keyboard->seat;
 
 	if (keyboard->device->keyboard->group != NULL) {
-		cg_keyboard_group_remove(keyboard);
+		cg_keyboard_group_remove_keyboard(keyboard);
 	}
 
 	if (wlr_seat_get_keyboard(seat->seat) == keyboard->device->keyboard) {
@@ -291,7 +290,7 @@ destroy_empty_wlr_keyboard_group(void *data)
 }
 
 static void
-cg_keyboard_group_remove(struct cg_keyboard *keyboard)
+cg_keyboard_group_remove_keyboard(struct cg_keyboard *keyboard)
 {
 	struct wlr_keyboard_group *wlr_group = keyboard->device->keyboard->group;
 

--- a/seat.c
+++ b/seat.c
@@ -318,16 +318,14 @@ handle_keyboard_destroy(struct wl_listener *listener, void *data)
 
 static void
 handle_keyboard_group_key(struct wl_listener *listener, void *data) {
-	struct cg_keyboard_group *cg_group =
-	    wl_container_of(listener, cg_group, key);
+	struct cg_keyboard_group *cg_group = wl_container_of(listener, cg_group, key);
 	handle_key_event(cg_group->keyboard, data);
 }
 
 static void
 handle_keyboard_group_modifiers(struct wl_listener *listener, void *data)
 {
-	struct cg_keyboard_group *group =
-	    wl_container_of(listener, group, modifiers);
+	struct cg_keyboard_group *group = wl_container_of(listener, group, modifiers);
 	handle_modifier_event(group->keyboard);
 }
 

--- a/seat.c
+++ b/seat.c
@@ -371,7 +371,6 @@ handle_new_keyboard(struct cg_seat *seat, struct wlr_input_device *device)
 
 	cg_keyboard_group_add(device, seat);
 
-	wl_signal_init(&device->events.destroy);
 	wlr_seat_set_keyboard(seat->seat, device);
 }
 

--- a/seat.c
+++ b/seat.c
@@ -284,12 +284,6 @@ cg_keyboard_destroy(struct cg_keyboard *keyboard)
 }
 
 static void
-destroy_empty_wlr_keyboard_group(void *data)
-{
-	wlr_keyboard_group_destroy(data);
-}
-
-static void
 cg_keyboard_group_remove_keyboard(struct cg_keyboard *keyboard)
 {
 	struct wlr_keyboard_group *wlr_group = keyboard->device->keyboard->group;
@@ -307,7 +301,7 @@ cg_keyboard_group_remove_keyboard(struct cg_keyboard *keyboard)
 		cg_keyboard_destroy(cg_group->keyboard);
 		free(cg_group);
 
-		destroy_empty_wlr_keyboard_group(wlr_group);
+		wlr_keyboard_group_destroy(wlr_group);
 	}
 }
 

--- a/seat.c
+++ b/seat.c
@@ -209,7 +209,8 @@ handle_new_pointer(struct cg_seat *seat, struct wlr_input_device *device)
 }
 
 static void
-handle_modifier_event(struct cg_keyboard *keyboard) {
+handle_modifier_event(struct cg_keyboard *keyboard)
+{
 	wlr_seat_set_keyboard(keyboard->seat->seat, keyboard->device);
 	wlr_seat_keyboard_notify_modifiers(keyboard->seat->seat, &keyboard->device->keyboard->modifiers);
 
@@ -331,14 +332,16 @@ handle_keyboard_group_key(struct wl_listener *listener, void *data) {
 }
 
 static void
-handle_keyboard_group_modifiers(struct wl_listener *listener, void *data) {
+handle_keyboard_group_modifiers(struct wl_listener *listener, void *data)
+{
 	struct cg_keyboard_group *group =
 	    wl_container_of(listener, group, modifiers);
 	handle_modifier_event(group->keyboard);
 }
 
 static bool
-keymaps_match(struct xkb_keymap *km1, struct xkb_keymap *km2) {
+keymaps_match(struct xkb_keymap *km1, struct xkb_keymap *km2)
+{
 	char *km1_str = xkb_keymap_get_as_string(km1, XKB_KEYMAP_FORMAT_TEXT_V1);
 	char *km2_str = xkb_keymap_get_as_string(km2, XKB_KEYMAP_FORMAT_TEXT_V1);
 	bool result = strcmp(km1_str, km2_str) == 0;
@@ -348,13 +351,15 @@ keymaps_match(struct xkb_keymap *km1, struct xkb_keymap *km2) {
 }
 
 static bool
-repeat_info_match(struct cg_keyboard *a, struct wlr_keyboard *b) {
+repeat_info_match(struct cg_keyboard *a, struct wlr_keyboard *b)
+{
 	return a->device->keyboard->repeat_info.rate == b->repeat_info.rate &&
 	       a->device->keyboard->repeat_info.delay == b->repeat_info.delay;
 }
 
 struct cg_keyboard *
-cg_keyboard_from_seat(struct cg_seat *seat, struct wlr_input_device *device) {
+cg_keyboard_from_seat(struct cg_seat *seat, struct wlr_input_device *device)
+{
 	struct cg_keyboard *keyboard = calloc(1, sizeof(struct cg_keyboard));
 	if (keyboard == NULL) {
 		wlr_log(WLR_ERROR, "Could not allocate new cg_keyboard.");
@@ -368,7 +373,8 @@ cg_keyboard_from_seat(struct cg_seat *seat, struct wlr_input_device *device) {
 }
 
 static void
-keyboard_group_add(struct cg_keyboard *keyboard) {
+keyboard_group_add(struct cg_keyboard *keyboard)
+{
 	struct cg_seat *seat = keyboard->seat;
 	struct wlr_keyboard *wlr_keyboard = keyboard->device->keyboard;
 	struct cg_keyboard_group *group;

--- a/seat.h
+++ b/seat.h
@@ -49,16 +49,8 @@ struct cg_seat {
 	struct wl_listener request_set_primary_selection;
 };
 
-struct cg_keyboard {
-	struct wl_list link; // seat::keyboards
-	struct cg_seat *seat;
-	struct wlr_input_device *device;
-
-	struct wl_listener destroy;
-};
-
 struct cg_keyboard_group {
-	struct cg_keyboard *keyboard;
+	struct wlr_keyboard *keyboard;
 
 	struct wlr_keyboard_group *wlr_group;
 	struct cg_seat *seat;

--- a/seat.h
+++ b/seat.h
@@ -14,12 +14,23 @@
 #define DEFAULT_XCURSOR "left_ptr"
 #define XCURSOR_SIZE 24
 
+struct cg_keyboard_group {
+	struct cg_keyboard *keyboard;
+
+	struct wlr_keyboard_group *wlr_group;
+	struct cg_seat *seat;
+	struct wl_listener key;
+	struct wl_listener modifiers;
+	struct wl_list link;
+};
+
 struct cg_seat {
 	struct wlr_seat *seat;
 	struct cg_server *server;
 	struct wl_listener destroy;
 
 	struct wl_list keyboards;
+	struct wl_list keyboard_groups;
 	struct wl_list pointers;
 	struct wl_list touch;
 	struct wl_listener new_input;
@@ -53,8 +64,6 @@ struct cg_keyboard {
 	struct cg_seat *seat;
 	struct wlr_input_device *device;
 
-	struct wl_listener modifiers;
-	struct wl_listener key;
 	struct wl_listener destroy;
 };
 

--- a/seat.h
+++ b/seat.h
@@ -50,8 +50,6 @@ struct cg_seat {
 };
 
 struct cg_keyboard_group {
-	struct wlr_keyboard *keyboard;
-
 	struct wlr_keyboard_group *wlr_group;
 	struct cg_seat *seat;
 	struct wl_listener key;

--- a/seat.h
+++ b/seat.h
@@ -56,7 +56,7 @@ struct cg_keyboard_group {
 	struct cg_seat *seat;
 	struct wl_listener key;
 	struct wl_listener modifiers;
-	struct wl_list link;// cg_seat::keyboard_groups
+	struct wl_list link; // cg_seat::keyboard_groups
 };
 
 struct cg_pointer {

--- a/seat.h
+++ b/seat.h
@@ -14,16 +14,6 @@
 #define DEFAULT_XCURSOR "left_ptr"
 #define XCURSOR_SIZE 24
 
-struct cg_keyboard_group {
-	struct cg_keyboard *keyboard;
-
-	struct wlr_keyboard_group *wlr_group;
-	struct cg_seat *seat;
-	struct wl_listener key;
-	struct wl_listener modifiers;
-	struct wl_list link;
-};
-
 struct cg_seat {
 	struct wlr_seat *seat;
 	struct cg_server *server;
@@ -65,6 +55,16 @@ struct cg_keyboard {
 	struct wlr_input_device *device;
 
 	struct wl_listener destroy;
+};
+
+struct cg_keyboard_group {
+	struct cg_keyboard *keyboard;
+
+	struct wlr_keyboard_group *wlr_group;
+	struct cg_seat *seat;
+	struct wl_listener key;
+	struct wl_listener modifiers;
+	struct wl_list link;// cg_seat::keyboard_groups
 };
 
 struct cg_pointer {


### PR DESCRIPTION
Hi,
OK, so this is my first pull request, so bear with me ;).

Some time back, wlroots introduced the wlr_keyboard_group feature which groups multiple keyboards together to a single logical keyboard. This is useful since often a single physical keyboard may advertise itself as multiple keyboards which may lead to problems with compositor-defined keybindings. (e.g. if cage where to be run with a keyboard on which Alt and Escape were advertised on different keyboards, this would prevent the keybinding from working)

As of today, this is unlikely to concern  many people since the provided keybinding will be rarely used and it many cases Alt and Escape will be on the same keyboard. Nevertheless, I think that it is worth the extra code as it facilates the extension of cage with more keybindings and, in addition, I find the concept of keyboard groups to be more elegant than the current solution. Furthermore, the way I have implemented this allows users to attach multiple keyboards and run keybindings even when pressing the keys on different keyboards.

More technically, this pull request implements support for `wlr_keyboard_group` by adding all attached keyboards to as few groups as possible (only keyboards with the same keymap and repeat_info can be put in the same group). It extends the `cg_seat` structure by a `keyboard_groups` member and takes care of initializing and removing the required data.

I do not currently have an external keyboard with which I could try hot-plugging, so if someone would have the possibility to do so, I would be glad to hear about the outcome!

So yeah, that's about it! I actually ran into an issue in a project based on cage that I'm working on which prompted me to implement this, so the issues described above actually occur in production. The code is heavily borrowed from sway and adapted to fit the way cage works.

Hope I didn't mess up too badly on my first PR ;)!
cheers,
project-repo