### PR TITLE
Don’t terminate display when no view is found

### DIFF
--- a/view.c
+++ b/view.c
@@ -258,14 +258,6 @@ void
 view_destroy(struct cg_view *view)
 {
 	struct cg_server *server = view->server;
-	bool ever_been_mapped = true;
-
-#if CAGE_HAS_XWAYLAND
-	if (view->type == CAGE_XWAYLAND_VIEW) {
-		struct cg_xwayland_view *xwayland_view = xwayland_view_from_view(view);
-		ever_been_mapped = xwayland_view->ever_been_mapped;
-	}
-#endif
 
 	if (view->wlr_surface != NULL) {
 		view_unmap(view);
@@ -278,10 +270,6 @@ view_destroy(struct cg_view *view)
 	if (!empty) {
 		struct cg_view *prev = wl_container_of(server->views.next, prev, link);
 		seat_set_focus(server->seat, prev);
-	} else if (ever_been_mapped) {
-		/* The list is empty and the last view has been
-		   mapped, so we can safely exit. */
-		wl_display_terminate(server->wl_display);
 	}
 }
 

--- a/xwayland.c
+++ b/xwayland.c
@@ -150,7 +150,6 @@ handle_xwayland_surface_map(struct wl_listener *listener, void *data)
 	xwayland_view->commit.notify = handle_xwayland_surface_commit;
 	wl_signal_add(&xwayland_view->xwayland_surface->surface->events.commit, &xwayland_view->commit);
 
-	xwayland_view->ever_been_mapped = true;
 	view_map(view, xwayland_view->xwayland_surface->surface);
 
 	view_damage_whole(view);

--- a/xwayland.h
+++ b/xwayland.h
@@ -9,21 +9,6 @@
 struct cg_xwayland_view {
 	struct cg_view view;
 	struct wlr_xwayland_surface *xwayland_surface;
-
-	/* Some applications that aren't yet Wayland-native or
-	   otherwise "special" (e.g. Firefox Nightly and Google
-	   Chrome/Chromium) spawn an XWayland surface upon startup
-	   that is almost immediately closed again. This makes Cage
-	   think there are no views left, which results in it
-	   exiting. However, after this initial (unmapped) surface,
-	   the "real" application surface is opened. This leads to
-	   these applications' startup sequences being interrupted by
-	   Cage exiting. Hence, to work around this issue, Cage checks
-	   whether an XWayland surface has ever been mapped and exits
-	   only if 1) the XWayland surface has ever been mapped and 2)
-	   this was the last surface Cage manages. */
-	bool ever_been_mapped;
-
 	struct wl_listener destroy;
 	struct wl_listener unmap;
 	struct wl_listener map;


### PR DESCRIPTION
Some apps like RetroArch will quit and fork itself to switch
modes (like from the menu to a loaded core). This means that for a
very short period of time we have no view available for Wayland. Right
now, Cage doesn’t actually exit when it does this terminate, so you
get this kind of zombie child process that is running but not showing
anything on the screen because there is no compositor.

The solution I have here is to just keep Cage’s Wayland server running
to avoid this issue. I’m open to other idea, but this seems sane to
me. Perhaps an alternative is to check if the process is still alive
when this happens, if not then we can do the quitting behavior. In
addition, we could make this an option if some users don’t want this
behavior.