### PR TITLE
Cage: drop gid before uid

### DIFF
--- a/cage.c
+++ b/cage.c
@@ -146,13 +146,14 @@ static bool
 drop_permissions(void)
 {
 	if (getuid() != geteuid() || getgid() != getegid()) {
-		if (setuid(getuid()) != 0 || setgid(getgid()) != 0) {
+		// Set the gid and uid in the correct order.
+		if (setgid(getgid()) != 0 || setuid(getuid()) != 0) {
 			wlr_log(WLR_ERROR, "Unable to drop root, refusing to start");
 			return false;
 		}
 	}
 
-	if (setuid(0) != -1) {
+	if (setgid(0) != -1 || setuid(0) != -1) {
 		wlr_log(WLR_ERROR,
 			"Unable to drop root (we shouldn't be able to restore it after setuid), refusing to start");
 		return false;


### PR DESCRIPTION
If setuid is called first then the target user may not have the ability to
setgid.

Refs: https://github.com/swaywm/sway/issues/4990