### PR TITLE
Add missing meson dependencies

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -136,8 +136,8 @@ cage_sources = [
 
 cage_headers = [
   configure_file(input: 'config.h.in',
-		 output: 'config.h',
-		 configuration: conf_data),
+                 output: 'config.h',
+                 configuration: conf_data),
   'idle_inhibit_v1.h',
   'output.h',
   'render.h',
@@ -171,10 +171,10 @@ executable(
 )
 
 summary = [
-	'',
-	'Cage @0@'.format(version),
-	'',
-	'    xwayland: @0@'.format(have_xwayland),
-	''
+  '',
+  'Cage @0@'.format(version),
+  '',
+  '    xwayland: @0@'.format(have_xwayland),
+  ''
 ]
 message('\n'.join(summary))

--- a/meson.build
+++ b/meson.build
@@ -39,6 +39,8 @@ wayland_protos = dependency('wayland-protocols', version: '>=1.14')
 wayland_server = dependency('wayland-server')
 pixman         = dependency('pixman-1')
 xkbcommon      = dependency('xkbcommon')
+udev           = dependency('libudev')
+egl            = dependency('egl')
 math           = cc.find_library('m')
 
 wl_protocol_dir = wayland_protos.get_pkgconfig_variable('pkgdatadir')
@@ -70,9 +72,11 @@ if get_option('xwayland')
     error('Cannot build Cage with XWayland support: wlroots has been built without it')
   else
     have_xwayland = true
+    xcb = dependency('xcb')
   endif
 else
   have_xwayland = false
+  xcb = dependency('', required : false)
 endif
 
 version = '@0@'.format(meson.project_version())
@@ -158,7 +162,10 @@ executable(
     wlroots,
     xkbcommon,
     pixman,
+    udev,
+    egl,
     math,
+    xcb,
   ],
   install: true,
 )


### PR DESCRIPTION
I noticed that some of the dependencies are not tracked in `meson.build` while packaging Cage for Nixpkgs but forgot to submit a patch after the last release (but it isn't a big deal anyway). The second commit is optional.

Note: The dependencies in the README are also out of sync: https://github.com/Hjdskes/cage/#building-and-running-cage
If you want to list the dependencies in the README I'd recommend using a list like Sway does (https://github.com/swaywm/sway#compiling-from-source) as that should be easier to keep in sync with `meson.build` (and to reflect optional, compile-time, etc. dependencies).

And thanks for the new release with wlroots 0.11 compatibility :)