### PR TITLE
seat.c: Make clangformat happy and simplify the control flow

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -132,8 +132,8 @@ cage_sources = [
 
 cage_headers = [
   configure_file(input: 'config.h.in',
-		 output: 'config.h',
-		 configuration: conf_data),
+                 output: 'config.h',
+                 configuration: conf_data),
   'idle_inhibit_v1.h',
   'output.h',
   'render.h',
@@ -164,10 +164,10 @@ executable(
 )
 
 summary = [
-	'',
-	'Cage @0@'.format(version),
-	'',
-	'    xwayland: @0@'.format(have_xwayland),
-	''
+  '',
+  'Cage @0@'.format(version),
+  '',
+  '    xwayland: @0@'.format(have_xwayland),
+  ''
 ]
 message('\n'.join(summary))

--- a/seat.c
+++ b/seat.c
@@ -229,13 +229,12 @@ handle_keybinding(struct cg_server *server, xkb_keysym_t sym)
 #ifdef DEBUG
 	if (sym == XKB_KEY_Escape) {
 		wl_display_terminate(server->wl_display);
-	} else
+		return true;
+	}
 #endif
-	if (server->allow_vt_switch && sym >= XKB_KEY_XF86Switch_VT_1
-			&& sym <= XKB_KEY_XF86Switch_VT_12) {
+	if (server->allow_vt_switch && sym >= XKB_KEY_XF86Switch_VT_1 && sym <= XKB_KEY_XF86Switch_VT_12) {
 		if (wlr_backend_is_multi(server->backend)) {
-			struct wlr_session *session =
-				wlr_backend_get_session(server->backend);
+			struct wlr_session *session = wlr_backend_get_session(server->backend);
 			if (session) {
 				unsigned vt = sym - XKB_KEY_XF86Switch_VT_1 + 1;
 				wlr_session_change_vt(session, vt);


### PR DESCRIPTION
This restores the original behaviour from 2cf40f7, is easier to read,
and satisfies clangformat.
This also doesn't call wlr_idle_notify_activity anymore, which was
probably unintended.