### PR TITLE
Add command line switches to disable pointer and touch

### DIFF
--- a/cage.1.scd
+++ b/cage.1.scd
@@ -27,12 +27,20 @@ activities outside the scope of the running application are prevented.
 	*last* Cage uses only the last connected monitor.
 	*extend* Cage extends the display across all connected monitors.
 
+*-P*
+	Disable pointer device. This comes in handy if a pointer device
+	is attached to the computer running *cage*, but undesirable for
+	application.
+
 *-r*
 	Rotate the output 90 degrees clockwise. This can be specified up to three
 	times, each resulting in an additional 90 degrees clockwise rotation.
 
 *-s*
 	Allow VT switching
+
+*-T*
+	Disable touch device. Like *-P*, but for touchscreens.
 
 *-v*
 	Show the version number and exit.

--- a/cage.c
+++ b/cage.c
@@ -191,9 +191,11 @@ usage(FILE *file, const char *cage)
 		" -h\t Display this help message\n"
 		" -m extend Extend the display across all connected outputs (default)\n"
 		" -m last Use only the last connected output\n"
+		" -P\t Disable pointer input\n"
 		" -r\t Rotate the output 90 degrees clockwise, specify up to three times\n"
 		" -s\t Allow VT switching\n"
 		" -v\t Show the version number and exit\n"
+		" -T\t Disable touch input\n"
 		"\n"
 		" Use -- when you want to pass arguments to APPLICATION\n",
 		cage);
@@ -204,9 +206,9 @@ parse_args(struct cg_server *server, int argc, char *argv[])
 {
 	int c;
 #ifdef DEBUG
-	while ((c = getopt(argc, argv, "dDhm:rsv")) != -1) {
+	while ((c = getopt(argc, argv, "dDhm:rsvPT")) != -1) {
 #else
-	while ((c = getopt(argc, argv, "dhm:rsv")) != -1) {
+	while ((c = getopt(argc, argv, "dhm:rsvPT")) != -1) {
 #endif
 		switch (c) {
 		case 'd':
@@ -235,6 +237,12 @@ parse_args(struct cg_server *server, int argc, char *argv[])
 			break;
 		case 's':
 			server->allow_vt_switch = true;
+			break;
+		case 'P':
+			server->disable_pointer = true;
+			break;
+		case 'T':
+			server->disable_touch = true;
 			break;
 		case 'v':
 			fprintf(stdout, "Cage version " CAGE_VERSION "\n");

--- a/seat.c
+++ b/seat.c
@@ -390,10 +390,12 @@ handle_new_input(struct wl_listener *listener, void *data)
 		handle_new_keyboard(seat, device);
 		break;
 	case WLR_INPUT_DEVICE_POINTER:
-		handle_new_pointer(seat, device);
+		if(!seat->server->disable_pointer)
+			handle_new_pointer(seat, device);
 		break;
 	case WLR_INPUT_DEVICE_TOUCH:
-		handle_new_touch(seat, device);
+		if(!seat->server->disable_touch)
+			handle_new_touch(seat, device);
 		break;
 	case WLR_INPUT_DEVICE_SWITCH:
 		wlr_log(WLR_DEBUG, "Switch input is not implemented");

--- a/server.h
+++ b/server.h
@@ -47,6 +47,8 @@ struct cg_server {
 
 	bool xdg_decoration;
 	bool allow_vt_switch;
+	bool disable_pointer;
+	bool disable_touch;
 	enum wl_output_transform output_transform;
 #ifdef DEBUG
 	bool debug_damage_tracking;


### PR DESCRIPTION
I am using a wireless keyboard with an integrated touchpad.
I do neither need nor want the touchpad, but I am unable to
attach the keyboard only (without the pointer device) to my
computer. I therefore find it convenient to simply disable
that device when starting `cage`. The switch for disabling
touch input is there for consistency. Maybe it comes in handy
to someone else at some point.

I don't have any previous experience with wayland, so there is
a chance that I simply missed some environment variable that
accomplishes the same. In this case, this commit would be
unnecessary.

The command line switches `P` and `T` are quite ad-hoc. I probably
would have gone for `--disable-pointer` and `--disable-touch` if
long command line switches had already been in use. If someone has
a better idea than `P` and `T`, please suggest it.