### PR TITLE
Virtual input

### DIFF
--- a/seat.c
+++ b/seat.c
@@ -226,6 +226,7 @@ handle_virtual_pointer(struct wl_listener *listener, void *data)
 	device->output_name = strdup(event->suggested_output->name);
 	/* event->suggested_seat should be checked if we handle multiple seats */
 	handle_new_pointer(seat, device);
+	update_capabilities(seat);
 }
 
 static void
@@ -408,6 +409,7 @@ handle_virtual_keyboard(struct wl_listener *listener, void *data)
 	 * to select the appropriate one */
 
 	handle_new_keyboard(seat, device, true);
+	update_capabilities(seat);
 }
 
 static void

--- a/seat.c
+++ b/seat.c
@@ -320,6 +320,8 @@ cg_keyboard_group_add(struct wlr_input_device *device, struct cg_seat *seat, boo
 
 	struct cg_keyboard_group *group;
 	wl_list_for_each (group, &seat->keyboard_groups, link) {
+		if (group->is_virtual)
+			continue;
 		struct wlr_keyboard_group *wlr_group = group->wlr_group;
 		if (wlr_keyboard_group_add_keyboard(wlr_group, wlr_keyboard)) {
 			wlr_log(WLR_DEBUG, "Added new keyboard to existing group");
@@ -337,6 +339,7 @@ create_new:
 		return;
 	}
 	cg_group->seat = seat;
+	cg_group->is_virtual = virtual;
 	cg_group->wlr_group = wlr_keyboard_group_create();
 	if (cg_group->wlr_group == NULL) {
 		wlr_log(WLR_ERROR, "Failed to create wlr keyboard group.");
@@ -352,10 +355,7 @@ create_new:
 	wlr_log(WLR_DEBUG, "Created keyboard group");
 
 	wlr_keyboard_group_add_keyboard(cg_group->wlr_group, wlr_keyboard);
-	if (!virtual)
-		wl_list_insert(&seat->keyboard_groups, &cg_group->link);
-	else
-		wl_list_init(&cg_group->link);
+	wl_list_insert(&seat->keyboard_groups, &cg_group->link);
 
 	wl_signal_add(&cg_group->wlr_group->keyboard.events.key, &cg_group->key);
 	cg_group->key.notify = handle_keyboard_group_key;

--- a/seat.c
+++ b/seat.c
@@ -6,11 +6,14 @@
  * See the LICENSE file accompanying this file.
  */
 
+#define _XOPEN_SOURCE 500
+
 #include "config.h"
 
 #include <assert.h>
 #include <linux/input-event-codes.h>
 #include <stdlib.h>
+#include <string.h>
 #include <wayland-server-core.h>
 #include <wlr/backend.h>
 #include <wlr/backend/multi.h>
@@ -216,6 +219,11 @@ handle_virtual_pointer(struct wl_listener *listener, void *data)
 	struct wlr_virtual_pointer_v1 *pointer = event->new_pointer;
 	struct wlr_input_device *device = &pointer->input_device;
 
+	/* We'll want to map the device back to an output later, this is a bit
+	 * sub-optimal (we could just keep the suggested_output), but just copy
+	 * its name so we do like other devices
+	 */
+	device->output_name = strdup(event->suggested_output->name);
 	/* event->suggested_seat should be checked if we handle multiple seats */
 	handle_new_pointer(seat, device);
 }

--- a/seat.h
+++ b/seat.h
@@ -25,6 +25,10 @@ struct cg_seat {
 	struct wl_list touch;
 	struct wl_listener new_input;
 
+	// These belong to higher level if multiple seats are allowed
+	struct wlr_virtual_keyboard_manager_v1 *virtual_keyboard;
+	struct wl_listener new_virtual_keyboard;
+
 	struct wlr_cursor *cursor;
 	struct wlr_xcursor_manager *xcursor_manager;
 	struct wl_listener cursor_motion;

--- a/seat.h
+++ b/seat.h
@@ -27,7 +27,9 @@ struct cg_seat {
 
 	// These belong to higher level if multiple seats are allowed
 	struct wlr_virtual_keyboard_manager_v1 *virtual_keyboard;
+	struct wlr_virtual_pointer_manager_v1 *virtual_pointer;
 	struct wl_listener new_virtual_keyboard;
+	struct wl_listener new_virtual_pointer;
 
 	struct wlr_cursor *cursor;
 	struct wlr_xcursor_manager *xcursor_manager;

--- a/seat.h
+++ b/seat.h
@@ -61,6 +61,7 @@ struct cg_keyboard_group {
 	struct wl_listener key;
 	struct wl_listener modifiers;
 	struct wl_list link; // cg_seat::keyboard_groups
+	bool is_virtual;
 };
 
 struct cg_pointer {


### PR DESCRIPTION
With these two patches, wayvnc can now be used with cage:
```
$ cage something
# figure out which wayland socket cage used
$ WAYLAND_DISPLAY=wayland-0 wayvnc
```
Note this does not appear to work with headless backend, e.g. starting cage with
`WLR_BACKENDS=headless WLR_LIBINPUT_NO_DEVICES=1 cage something`
does start and wayvnc connects/displays output, but there are tons of errors
and input does not work

Fixes #133 

^ without wayvnc or similar working I assume there was little interest in making headless work, so I assume there isn't any known issue with headless?
I'm probably happy with just drm backend but that might be worth looking at a bit further...