### PR TITLE
command line switch to auto-map input to output if only one output is available.

### DIFF
--- a/cage.c
+++ b/cage.c
@@ -184,6 +184,7 @@ usage(FILE *file, const char *cage)
 	fprintf(file,
 		"Usage: %s [OPTIONS] [--] APPLICATION\n"
 		"\n"
+		" -a\t Auto-map input device to output (Useful when only one output present)\n"
 		" -d\t Don't draw client side decorations, when possible\n"
 #ifdef DEBUG
 		" -D\t Turn on damage tracking debugging\n"
@@ -204,11 +205,14 @@ parse_args(struct cg_server *server, int argc, char *argv[])
 {
 	int c;
 #ifdef DEBUG
-	while ((c = getopt(argc, argv, "dDhm:rsv")) != -1) {
+	while ((c = getopt(argc, argv, "adDhm:rsv")) != -1) {
 #else
-	while ((c = getopt(argc, argv, "dhm:rsv")) != -1) {
+	while ((c = getopt(argc, argv, "adhm:rsv")) != -1) {
 #endif
 		switch (c) {
+		case 'a':
+			server->auto_map_output = true;
+			break;
 		case 'd':
 			server->xdg_decoration = true;
 			break;

--- a/seat.c
+++ b/seat.c
@@ -129,12 +129,21 @@ update_capabilities(struct cg_seat *seat)
 static void
 map_input_device_to_output(struct cg_seat *seat, struct wlr_input_device *device)
 {
+	struct cg_output *output;
 	if (!device->output_name) {
-		wlr_log(WLR_INFO, "Input device %s cannot be mapped to an output device\n", device->name);
-		return;
+		if (wl_list_length(&seat->server->outputs) == 1 && seat->server->auto_map_output) {
+			wl_list_for_each (output, &seat->server->outputs, link) {
+				wlr_log(WLR_INFO, "Input device %s does not have an output name, mapping to only output %s\n", device->name,
+					output->wlr_output->name);
+				wlr_cursor_map_input_to_output(seat->cursor, device, output->wlr_output);
+				return;
+			}
+		} else {
+			wlr_log(WLR_INFO, "Input device %s cannot be mapped to an output device\n", device->name);
+			return;
+		}
 	}
 
-	struct cg_output *output;
 	wl_list_for_each (output, &seat->server->outputs, link) {
 		if (strcmp(device->output_name, output->wlr_output->name) == 0) {
 			wlr_log(WLR_INFO, "Mapping input device %s to output device %s\n", device->name,

--- a/server.h
+++ b/server.h
@@ -45,6 +45,7 @@ struct cg_server {
 	struct wl_listener new_xwayland_surface;
 #endif
 
+	bool auto_map_output;
 	bool xdg_decoration;
 	bool allow_vt_switch;
 	enum wl_output_transform output_transform;


### PR DESCRIPTION
As I stated here:
https://github.com/Hjdskes/cage/pull/167#issuecomment-864577332

I understand wanting to avoid scenarios where things break in non-obvious ways, but perhaps a reasonable compromise could be to require a command line switch to enable this behavior.

This feature would be very useful to me because I use Cage in a production environment where I re-use a common disk image between 10+ different products (and growing), and minimizing configuration saves me and my techs a lot of time.