### PR TITLE
Set xdg_toplevel geometry for fullscreen clients

### DIFF
--- a/xdg_shell.c
+++ b/xdg_shell.c
@@ -242,6 +242,8 @@ handle_xdg_shell_surface_request_fullscreen(struct wl_listener *listener, void *
 {
 	struct cg_xdg_shell_view *xdg_shell_view = wl_container_of(listener, xdg_shell_view, request_fullscreen);
 	struct wlr_xdg_toplevel_set_fullscreen_event *event = data;
+	struct wlr_box *layout_box = wlr_output_layout_get_box(xdg_shell_view->view.server->output_layout, NULL);
+	wlr_xdg_toplevel_set_size(xdg_shell_view->xdg_surface, layout_box->width, layout_box->height);
 	wlr_xdg_toplevel_set_fullscreen(xdg_shell_view->xdg_surface, event->fullscreen);
 }
 


### PR DESCRIPTION
Certain clients (like Chromium in Kiosk mode) don't like figuring out their own window geometry if they display in fullscreen mode. Since setting this is very easy for cage, let's give them the correct geometry instead implicitly passing (0, 0) and letting them figure it out.

Not sure if reaching this deep into xdg_shell_view is a good idea, but I couldn't find a closer reference which would give access to the output layout.