### PR TITLE
Make the Cage multi-monitor layout configurable

### DIFF
--- a/cage.1.scd
+++ b/cage.1.scd
@@ -27,6 +27,11 @@ activities outside the scope of the running application are prevented.
 	*last* Cage uses only the last connected monitor.
 	*extend* Cage extends the display across all connected monitors.
 
+*-e* <mode>
+	Set the monitor addition mode, if display is extended across all connected monitors.
+	*auto* Cage places monitors automatically.
+	*right* Cage places each newly-connected monitor on the right of the rightmost connected monitor.
+
 *-r*
 	Rotate the output 90 degrees clockwise. This can be specified up to three
 	times, each resulting in an additional 90 degrees clockwise rotation.

--- a/cage.c
+++ b/cage.c
@@ -191,6 +191,8 @@ usage(FILE *file, const char *cage)
 		" -h\t Display this help message\n"
 		" -m extend Extend the display across all connected outputs (default)\n"
 		" -m last Use only the last connected output\n"
+		" -e auto Automatically place newly connected outputs (default)\n"
+		" -e right Place newly connected outputs on the right\n"
 		" -r\t Rotate the output 90 degrees clockwise, specify up to three times\n"
 		" -s\t Allow VT switching\n"
 		" -v\t Show the version number and exit\n"
@@ -204,9 +206,9 @@ parse_args(struct cg_server *server, int argc, char *argv[])
 {
 	int c;
 #ifdef DEBUG
-	while ((c = getopt(argc, argv, "dDhm:rsv")) != -1) {
+	while ((c = getopt(argc, argv, "dDhm:e:rsv")) != -1) {
 #else
-	while ((c = getopt(argc, argv, "dhm:rsv")) != -1) {
+	while ((c = getopt(argc, argv, "dhm:e:rsv")) != -1) {
 #endif
 		switch (c) {
 		case 'd':
@@ -225,6 +227,13 @@ parse_args(struct cg_server *server, int argc, char *argv[])
 				server->output_mode = CAGE_MULTI_OUTPUT_MODE_LAST;
 			} else if (strcmp(optarg, "extend") == 0) {
 				server->output_mode = CAGE_MULTI_OUTPUT_MODE_EXTEND;
+			}
+			break;
+		case 'e':
+			if (strcmp(optarg, "right") == 0) {
+				server->output_extend_mode = CAGE_OUTPUT_EXTEND_MODE_RIGHT;
+			} else if (strcmp(optarg, "auto") == 0) {
+				server->output_extend_mode = CAGE_OUTPUT_EXTEND_MODE_AUTO;
 			}
 			break;
 		case 'r':

--- a/output.c
+++ b/output.c
@@ -237,7 +237,7 @@ scan_out_primary_view(struct cg_output *output)
 }
 
 static void
-output_enable(struct cg_output *output)
+output_enable(struct cg_server *server, struct cg_output *output)
 {
 	struct wlr_output *wlr_output = output->wlr_output;
 
@@ -246,7 +246,23 @@ output_enable(struct cg_output *output)
 	 * duplicate the enabled property in cg_output. */
 	wlr_log(WLR_DEBUG, "Enabling output %s", wlr_output->name);
 
-	wlr_output_layout_add_auto(output->server->output_layout, wlr_output);
+	if (server->output_extend_mode == CAGE_OUTPUT_EXTEND_MODE_RIGHT) {
+		int max_x = 0, max_x_y = 0;
+		struct wlr_output_layout_output *l_output;
+		wl_list_for_each(l_output, &output->server->output_layout->outputs, link) {
+			int width, height;
+			wlr_output_effective_resolution(l_output->output, &width, &height);
+			if (l_output->x + width > max_x) {
+				max_x = l_output->x + width;
+				max_x_y = l_output->y;
+			}
+		}
+
+		wlr_output_layout_add(output->server->output_layout, wlr_output, max_x, max_x_y);
+	} else {
+		wlr_output_layout_add_auto(output->server->output_layout, wlr_output);
+	}
+
 	wlr_output_enable(wlr_output, true);
 	wlr_output_commit(wlr_output);
 }
@@ -411,7 +427,7 @@ output_destroy(struct cg_output *output)
 	} else if (server->output_mode == CAGE_MULTI_OUTPUT_MODE_LAST) {
 		struct cg_output *prev = wl_container_of(server->outputs.next, prev, link);
 		if (prev) {
-			output_enable(prev);
+			output_enable(server, prev);
 
 			struct cg_view *view;
 			wl_list_for_each (view, &server->views, link) {
@@ -482,7 +498,7 @@ handle_new_output(struct wl_listener *listener, void *data)
 			wlr_output->scale);
 	}
 
-	output_enable(output);
+	output_enable(server, output);
 
 	struct cg_view *view;
 	wl_list_for_each (view, &output->server->views, link) {

--- a/server.h
+++ b/server.h
@@ -21,6 +21,11 @@ enum cg_multi_output_mode {
 	CAGE_MULTI_OUTPUT_MODE_LAST,
 };
 
+enum cg_output_extend_mode {
+	CAGE_OUTPUT_EXTEND_MODE_AUTO,
+	CAGE_OUTPUT_EXTEND_MODE_RIGHT,
+};
+
 struct cg_server {
 	struct wl_display *wl_display;
 	struct wl_list views;
@@ -33,6 +38,7 @@ struct cg_server {
 	struct wl_list inhibitors;
 
 	enum cg_multi_output_mode output_mode;
+	enum cg_output_extend_mode output_extend_mode;
 	struct wlr_output_layout *output_layout;
 	/* Includes disabled outputs; depending on the output_mode
 	 * some outputs may be disabled. */


### PR DESCRIPTION
Because all displays are auto-configured in Cage, the "automatic" wlroots layout selection logic places all new monitors on the left.

https://github.com/swaywm/wlroots/blob/3d0848daae40a8a471282431eac8310e5d051d33/types/wlr_output_layout.c#L87

```
/**
 * This must be called whenever the layout changes to reconfigure the auto
 * configured outputs and emit the `changed` event.
 *
 * Auto configured outputs are placed to the right of the north east corner of
 * the rightmost output in the layout in a horizontal line.
 */
```

But all displays are auto-configured in our setup, because we don't use wlr-randr or something, so we reach this block:

```
	if (max_x == INT_MIN) {
		// there are no manually configured outputs
		max_x = 0;
		max_x_y = 0;
	}

	wl_list_for_each(l_output, &layout->outputs, link) {
		if (!l_output->state->auto_configured) {
			continue;
		}
                ...
		l_output->x = max_x;
		l_output->y = max_x_y;
	}
```

This PR makes it possible to ask Cage to add monitors on the right, and not on the left, using `-e right`. Additional modes can be added in the future.