### PR TITLE
Add basic wlr-output-management support

### DIFF
--- a/cage.1.scd
+++ b/cage.1.scd
@@ -27,10 +27,6 @@ activities outside the scope of the running application are prevented.
 	*last* Cage uses only the last connected monitor.
 	*extend* Cage extends the display across all connected monitors.
 
-*-r*
-	Rotate the output 90 degrees clockwise. This can be specified up to three
-	times, each resulting in an additional 90 degrees clockwise rotation.
-
 *-s*
 	Allow VT switching
 

--- a/cage.c
+++ b/cage.c
@@ -192,7 +192,6 @@ usage(FILE *file, const char *cage)
 		" -h\t Display this help message\n"
 		" -m extend Extend the display across all connected outputs (default)\n"
 		" -m last Use only the last connected output\n"
-		" -r\t Rotate the output 90 degrees clockwise, specify up to three times\n"
 		" -s\t Allow VT switching\n"
 		" -v\t Show the version number and exit\n"
 		"\n"
@@ -204,7 +203,7 @@ static bool
 parse_args(struct cg_server *server, int argc, char *argv[])
 {
 	int c;
-	while ((c = getopt(argc, argv, "dhm:rsv")) != -1) {
+	while ((c = getopt(argc, argv, "dhm:sv")) != -1) {
 		switch (c) {
 		case 'd':
 			server->xdg_decoration = true;
@@ -217,12 +216,6 @@ parse_args(struct cg_server *server, int argc, char *argv[])
 				server->output_mode = CAGE_MULTI_OUTPUT_MODE_LAST;
 			} else if (strcmp(optarg, "extend") == 0) {
 				server->output_mode = CAGE_MULTI_OUTPUT_MODE_EXTEND;
-			}
-			break;
-		case 'r':
-			server->output_transform++;
-			if (server->output_transform > WL_OUTPUT_TRANSFORM_270) {
-				server->output_transform = WL_OUTPUT_TRANSFORM_NORMAL;
 			}
 			break;
 		case 's':

--- a/cage.c
+++ b/cage.c
@@ -28,6 +28,7 @@
 #include <wlr/types/wlr_idle.h>
 #include <wlr/types/wlr_idle_inhibit_v1.h>
 #include <wlr/types/wlr_output_layout.h>
+#include <wlr/types/wlr_output_management_v1.h>
 #include <wlr/types/wlr_presentation_time.h>
 #include <wlr/types/wlr_scene.h>
 #include <wlr/types/wlr_screencopy_v1.h>
@@ -444,6 +445,17 @@ main(int argc, char *argv[])
 		ret = 1;
 		goto end;
 	}
+
+	server.output_manager_v1 = wlr_output_manager_v1_create(server.wl_display);
+	if (!server.output_manager_v1) {
+		wlr_log(WLR_ERROR, "Unable to create the output manager");
+		ret = 1;
+		goto end;
+	}
+	server.output_manager_apply.notify = handle_output_manager_apply;
+	wl_signal_add(&server.output_manager_v1->events.apply, &server.output_manager_apply);
+	server.output_manager_test.notify = handle_output_manager_test;
+	wl_signal_add(&server.output_manager_v1->events.test, &server.output_manager_test);
 
 	gamma_control_manager = wlr_gamma_control_manager_v1_create(server.wl_display);
 	if (!gamma_control_manager) {

--- a/output.c
+++ b/output.c
@@ -223,8 +223,6 @@ handle_new_output(struct wl_listener *listener, void *data)
 		}
 	}
 
-	wlr_output_set_transform(wlr_output, output->server->output_transform);
-
 	if (server->output_mode == CAGE_MULTI_OUTPUT_MODE_LAST) {
 		struct cg_output *next = wl_container_of(output->link.next, next, link);
 		if (next) {

--- a/output.h
+++ b/output.h
@@ -21,6 +21,8 @@ struct cg_output {
 	struct wl_list link; // cg_server::outputs
 };
 
+void handle_output_manager_apply(struct wl_listener *listener, void *data);
+void handle_output_manager_test(struct wl_listener *listener, void *data);
 void handle_new_output(struct wl_listener *listener, void *data);
 void output_set_window_title(struct cg_output *output, const char *title);
 

--- a/server.h
+++ b/server.h
@@ -50,7 +50,6 @@ struct cg_server {
 
 	bool xdg_decoration;
 	bool allow_vt_switch;
-	enum wl_output_transform output_transform;
 };
 
 #endif

--- a/server.h
+++ b/server.h
@@ -47,6 +47,9 @@ struct cg_server {
 #if CAGE_HAS_XWAYLAND
 	struct wl_listener new_xwayland_surface;
 #endif
+	struct wlr_output_manager_v1 *output_manager_v1;
+	struct wl_listener output_manager_apply;
+	struct wl_listener output_manager_test;
 
 	bool xdg_decoration;
 	bool allow_vt_switch;


### PR DESCRIPTION
This allows an .xinitrc style script that uses wlr-randr to create a custom layout right after Cage is started.