### PR TITLE
Explicitly create wlr_subcompositor

### DIFF
--- a/cage.c
+++ b/cage.c
@@ -32,6 +32,7 @@
 #include <wlr/types/wlr_scene.h>
 #include <wlr/types/wlr_screencopy_v1.h>
 #include <wlr/types/wlr_server_decoration.h>
+#include <wlr/types/wlr_subcompositor.h>
 #include <wlr/types/wlr_viewporter.h>
 #if CAGE_HAS_XWAYLAND
 #include <wlr/types/wlr_xcursor_manager.h>
@@ -254,6 +255,7 @@ main(int argc, char *argv[])
 	struct wl_event_source *sigterm_source = NULL;
 	struct wl_event_source *sigchld_source = NULL;
 	struct wlr_compositor *compositor = NULL;
+	struct wlr_subcompositor *subcompositor = NULL;
 	struct wlr_data_device_manager *data_device_manager = NULL;
 	struct wlr_server_decoration_manager *server_decoration_manager = NULL;
 	struct wlr_xdg_decoration_manager_v1 *xdg_decoration_manager = NULL;
@@ -347,6 +349,13 @@ main(int argc, char *argv[])
 	compositor = wlr_compositor_create(server.wl_display, server.renderer);
 	if (!compositor) {
 		wlr_log(WLR_ERROR, "Unable to create the wlroots compositor");
+		ret = 1;
+		goto end;
+	}
+
+	subcompositor = wlr_subcompositor_create(server.wl_display);
+	if (!subcompositor) {
+		wlr_log(WLR_ERROR, "Unable to create the wlroots subcompositor");
 		ret = 1;
 		goto end;
 	}


### PR DESCRIPTION
[wlroots 0.16](https://gitlab.freedesktop.org/wlroots/wlroots/-/issues/3347) splits the compositor and subcompositor, so the subcompositor now needs to be created explicitly.

This may just want to sit as a PR for now, depending on the plan for the next release of Cage.