### PR TITLE
Virtual input

### DIFF
--- a/cage.c
+++ b/cage.c
@@ -35,6 +35,8 @@
 #include <wlr/types/wlr_single_pixel_buffer_v1.h>
 #include <wlr/types/wlr_subcompositor.h>
 #include <wlr/types/wlr_viewporter.h>
+#include <wlr/types/wlr_virtual_keyboard_v1.h>
+#include <wlr/types/wlr_virtual_pointer_v1.h>
 #if CAGE_HAS_XWAYLAND
 #include <wlr/types/wlr_xcursor_manager.h>
 #endif
@@ -270,6 +272,8 @@ main(int argc, char *argv[])
 	struct wlr_single_pixel_buffer_manager_v1 *single_pixel_buffer = NULL;
 	struct wlr_xdg_output_manager_v1 *output_manager = NULL;
 	struct wlr_gamma_control_manager_v1 *gamma_control_manager = NULL;
+	struct wlr_virtual_keyboard_manager_v1 *virtual_keyboard = NULL;
+	struct wlr_virtual_pointer_manager_v1 *virtual_pointer = NULL;
 	struct wlr_viewporter *viewporter = NULL;
 	struct wlr_presentation *presentation = NULL;
 	struct wlr_xdg_shell *xdg_shell = NULL;
@@ -481,6 +485,22 @@ main(int argc, char *argv[])
 		ret = 1;
 		goto end;
 	}
+
+	virtual_keyboard = wlr_virtual_keyboard_manager_v1_create(server.wl_display);
+	if (!virtual_keyboard) {
+		wlr_log(WLR_ERROR, "Unable to create the virtual keyboard manager");
+		ret = 1;
+		goto end;
+	}
+	wl_signal_add(&virtual_keyboard->events.new_virtual_keyboard, &server.new_virtual_keyboard);
+
+	virtual_pointer = wlr_virtual_pointer_manager_v1_create(server.wl_display);
+	if (!virtual_pointer) {
+		wlr_log(WLR_ERROR, "Unable to create the virtual pointer manager");
+		ret = 1;
+		goto end;
+	}
+	wl_signal_add(&virtual_pointer->events.new_virtual_pointer, &server.new_virtual_pointer);
 
 #if CAGE_HAS_XWAYLAND
 	xwayland = wlr_xwayland_create(server.wl_display, compositor, true);

--- a/seat.h
+++ b/seat.h
@@ -55,6 +55,7 @@ struct cg_keyboard_group {
 	struct wl_listener key;
 	struct wl_listener modifiers;
 	struct wl_list link; // cg_seat::keyboard_groups
+	bool is_virtual;
 };
 
 struct cg_pointer {

--- a/server.h
+++ b/server.h
@@ -12,10 +12,6 @@
 #include <wlr/xwayland.h>
 #endif
 
-#include "output.h"
-#include "seat.h"
-#include "view.h"
-
 enum cg_multi_output_mode {
 	CAGE_MULTI_OUTPUT_MODE_EXTEND,
 	CAGE_MULTI_OUTPUT_MODE_LAST,
@@ -44,6 +40,9 @@ struct cg_server {
 
 	struct wl_listener xdg_toplevel_decoration;
 	struct wl_listener new_xdg_shell_surface;
+
+	struct wl_listener new_virtual_keyboard;
+	struct wl_listener new_virtual_pointer;
 #if CAGE_HAS_XWAYLAND
 	struct wl_listener new_xwayland_surface;
 #endif


### PR DESCRIPTION
Successor to #189. Fixed conflicts and updated.

Fixes #21 
Fixes #133 

Tested with:

`WLR_BACKENDS=headless WLR_NO_HARDWARE_CURSORS=1 WLR_LIBINPUT_NO_DEVICES=1 WLR_HEADLESS_OUTPUTS=1 ./cage`